### PR TITLE
Addition of user-defined rows and columns

### DIFF
--- a/ccdc/ccdc.c
+++ b/ccdc/ccdc.c
@@ -3,6 +3,8 @@
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <sys/timeb.h>
 
 #include "const.h"
@@ -11,6 +13,7 @@
 #include "input.h"
 #include "output.h"
 #include "ccdc.h"
+//#include "matio.h"
 #include "defines.h"
 
 const char scene_list_name[] = {"scene_list.txt"};  /* default, if none specified */
@@ -65,6 +68,7 @@ Date        Programmer       Reason
                              values are non-fill is the x/y location in
                              an area of "pixel overlap", otherwise it is
                              "scene overlap" if one of them is fill.
+20160218    Song Guo         Changed to use Zhe's stacked ARD data as inputs
 20160421    Brian Davis      Moved the reading from stdin to a function
                              in input.c.  Added and formatted comments.
                              Moved the accumlators of fmask pixel
@@ -84,6 +88,13 @@ Date        Programmer       Reason
                                      matlab_2d_float_mean
                              calling matlab_float_2d_partial_median instead of
                                      matlab_2d_partial_mean
+20160526    Brian Davis      Added reading of bip and bip_lines
+                             More consolodation of things in input.c instead
+                             of ccdc.c
+                             Changed initialization of num_fc from 0 to 1 (sguo)
+                             removed intialization of update_num_c to 8.
+                             removed intialization of v_dif_nrm to 0.0.
+20160901    Brian Davis      Initialized update_num_c to 8.
 
 When reading fmask values to detmermine fill vs. usability,
 those "scenes" have been sorted, so one could test for:
@@ -126,7 +137,7 @@ int main (int argc, char *argv[])
                                      /* containing scene names                */
     int num_scenes = MAX_SCENE_LIST; /* Number of input scenes defined        */
     int num_c = 8;                   /* Max number of coefficients for model  */
-    int num_fc = 0;                  /* Intialize NUM of Functional Curves    */
+    int num_fc = -1;                  /* Intialize NUM of Functional Curves    */
     int rec_fc;                      /* Record num. of functional curves      */
     float v_start[NUM_LASSO_BANDS];  /* Vector for start of observation(s)    */
     float v_end[NUM_LASSO_BANDS];    /* Vector for end of observastion(s)     */
@@ -135,8 +146,11 @@ int main (int argc, char *argv[])
     float **v_diff;
     int *sdate;                      /* Pointer to list of acquisition dates  */
     int *updated_sdate_array;        /* Sdate array after cfmask filtering    */
+    int *sdate_pix;                  /* updated list of sdate values          */
     Input_meta_t *meta;              /* Structure for ENVI metadata hdr info  */
     int row, col;                    /* The input indecies of the data frame. */
+    int nrows;                       /* the number of rows in "tile" of data  */
+    int ncols;                       /* the number of columns in "row" of data*/
     int clr_sum = 0;                 /* Total number of clear cfmask pixels   */
     int sn_sum = 0;                  /* Total number of snow  cfmask pixels   */
     int all_sum = 0;                 /* Total of all cfmask pixels            */
@@ -150,10 +164,11 @@ int main (int argc, char *argv[])
     float **cpy;                     /* nunber of clear pixels Y ?            */
     int i_start;                     /* The first observation for TSFit       */
     int end;                         /* The end of clear observations of total*/
+    int end2;                        /* place holder until final end is found */
     float **fit_cft;                 /* Fitted coefficients 2-D array.        */
     float *rmse;                     /* Root Mean Squared Error array.        */
     int i_span;                      /* index for span of consecutive obs. ?  */
-    int update_num_c = 8;            /* Number of coefficients to update      */
+    int update_num_c=MIN_NUM_C;      /* Number of coefficients to update      */
     int bl_train;                    /* Flag for which way to train the model.*/
     float time_span;                 /* Span of time in no. of years.         */
     int *bl_ids;
@@ -163,12 +178,12 @@ int main (int argc, char *argv[])
     int *rm_ids;
     int rm_ids_len;
     int i_rec;                       /* start of model before noise removal   */
-    float v_dif_norm = 0.0;
+    float v_dif_norm;                /* vector for normalized difference vals */
     int i_count;                     /* Count difference of i each iteration  */
     float **v_dif_mag;               /* vector for magnitude of differences.  */
     int i_conse, i_b;
-    float *vec_mag; /* what is the differece */ /* they are used in 2 different branches */
-    float *vec_magg;/* these two?            */ /* this one is never freed */
+    float *vec_mag;                  /* permanent storage for magnitude vector*/
+    float *vec_magg;                 /* temp storage for magnitude vecor      */
     float v_dif_mean;
     float vec_magg_min;
     float **rec_v_dif;
@@ -176,7 +191,7 @@ int main (int argc, char *argv[])
     float **temp_v_dif;              /* for the thermal band.......           */
     float adj_rmse[TOTAL_IMAGE_BANDS];/* Adjusted RMSE for all bands          */
     float mini_rmse;                 /* Mimimum RMSE                          */
-    int bl_tmask; /* not used ? */
+    int bl_tmask;
     int n_rmse;                      /* number of RMSE values                 */
     float tmpcg_rmse[NUM_LASSO_BANDS]; /* to temporarily change RMSE          */
     int d_rt;
@@ -192,7 +207,8 @@ int main (int argc, char *argv[])
     int ids_len;                     /* number of ids, incremented continuously*/
     unsigned char *fmask_buf;       /* cfmask pixel value array.              */
     unsigned char *updated_fmask_buf;/*sub-set of fmask buf, valid pixels only*/
-    int **buf;                      /* This is the image bands buffer.        */
+    //int **buf;                      /* This is the image bands buffer.        */
+    int *buf;                       /* This is the image bands buffer.        */
     FILE ***fp_tifs;                /* Array of file pointers of multiple     */
                                     /*     band files for specific dates.     */
     FILE **fp_bip;                  /* Array of file pointers of BIP files    */
@@ -206,6 +222,7 @@ int main (int argc, char *argv[])
     int inputs_specified;        /* the number input scenes defined.          */
     int valid_num_scenes;        /* number of scenes after cfmask counts and  */
                                  /* swath overlap eliminated                  */
+    int clear_sum = 0;           /* counter for cfmask clear pixels.          */
     int water_sum = 0;           /* counter for cfmask water pixels.          */
     int shadow_sum = 0;          /* counter for cfmask shadow pixels.         */
     int cloud_sum = 0;           /* counter for cfmask cloud pixels.          */
@@ -222,10 +239,14 @@ int main (int argc, char *argv[])
     int swath_overlap_count = 0; /* it may or may not be in an overlap area.  */
     time_t now;                  /* For logging the start, stop, and some     */
     time (&now);                 /*     intermediate times.                   */
+    int row_inx, col_inx;        /* for looping through 2D array of pixels    */
+    int row_count, col_count;    /* to keep track of row/col relative to start*/
+    int offset;                  /* for determining buf pointer location of pix*/
+    int scene_inx;               /* for looping through scenes                */
 
     if (verbose)
     {
-        snprintf (msg_str, sizeof(msg_str), "CCDC version 05.01 start_time=%s\n", ctime (&now));
+        snprintf (msg_str, sizeof(msg_str), "CCDC version 05.02 start_time=%s\n", ctime (&now));
         LOG_MESSAGE (msg_str, FUNC_NAME);
     }
 
@@ -245,8 +266,8 @@ int main (int argc, char *argv[])
     /*                                                                */
     /******************************************************************/
 
-    status = get_args (argc, argv, &row, &col, in_path, out_path, data_type,
-                       scene_list_file, &verbose);
+    status = get_args (argc, argv, &row, &col, &nrows, &ncols, in_path,
+                       out_path, data_type, scene_list_file, &verbose);
     if (status != SUCCESS)
     {
         RETURN_ERROR ("calling get_args", FUNC_NAME, EXIT_FAILURE);
@@ -281,13 +302,13 @@ int main (int argc, char *argv[])
         debug = false;
     }
 
-    updated_fmask_buf = malloc(valid_num_scenes * sizeof(unsigned char));
+    updated_fmask_buf = malloc(valid_num_scenes * ncols * nrows * sizeof(unsigned char));
     if (updated_fmask_buf == NULL)
     {
         RETURN_ERROR("ERROR allocating updated_fmask_buf memory", FUNC_NAME, FAILURE);
     }
 
-    updated_sdate_array = malloc(valid_num_scenes * sizeof(int));
+    updated_sdate_array = malloc(valid_num_scenes * ncols * nrows * sizeof(int));
     if (updated_sdate_array == NULL)
     {
         RETURN_ERROR("ERROR allocating updated_sdate memory", FUNC_NAME, FAILURE);
@@ -304,7 +325,9 @@ int main (int argc, char *argv[])
 
     {
 
-        buf = (int **) allocate_2d_array (TOTAL_IMAGE_BANDS, valid_num_scenes, sizeof (int));
+        //buf = (int **) allocate_2d_array (TOTAL_IMAGE_BANDS * ncols * nrows,
+        //                                  valid_num_scenes, sizeof (int));
+        buf = malloc (TOTAL_IMAGE_BANDS * ncols * nrows * valid_num_scenes * sizeof (int));
         if (buf == NULL)
         {
             RETURN_ERROR ("Allocating buf memory", FUNC_NAME, FAILURE);
@@ -504,7 +527,7 @@ int main (int argc, char *argv[])
         /*                                                            */
         /**************************************************************/
 
-        sdate = malloc(num_scenes * sizeof(int));
+        sdate = malloc(num_scenes * nrows * ncols * sizeof(int));
         if (sdate == NULL)
         {
             RETURN_ERROR("ERROR allocating sdate memory", FUNC_NAME, FAILURE);
@@ -531,18 +554,6 @@ int main (int argc, char *argv[])
     
         /**************************************************************/
         /*                                                            */
-        /* Do all of the memory allocations for buffers/arrays which  */
-        /* are required to do the reading of files for pixel value    */
-        /* assessment and storage. Fill value and "pixel overlap"     */
-        /* pixels will not be saved and used to update counters.      */
-        /* Also, do the remaining allocations for all buffers/arrays  */
-        /* necessary for the ccdc algorithm, because after filling the*/
-        /* band data arrays here, that will be the next step.         */
-        /*                                                            */
-        /******************************************************************/
-
-        /**************************************************************/
-        /*                                                            */
         /* Allocate memory for fp_tifs and all the pointers required   */
         /* for the branch which reads files from the filesystem.      */
         /*                                                            */
@@ -566,16 +577,210 @@ int main (int argc, char *argv[])
             }
         }
     
+        /**************************************************************/
+        /*                                                            */
+        /* Do all of the memory allocations for buffers/arrays which  */
+        /* are required to do the reading of files for pixel value    */
+        /* assessment and storage. Fill value and "swath overlap"     */
+        /* pixels will not be saved nor used to update counters.      */
+        /*                                                            */
+        /******************************************************************/
+
+        fmask_buf = malloc(num_scenes * ncols * nrows * sizeof(unsigned char));
+        if (fmask_buf == NULL)
+        {
+            RETURN_ERROR("ERROR allocating fmask_buf memory", FUNC_NAME, FAILURE);
+        }
+    
+        //buf = (int **) allocate_2d_array ((TOTAL_IMAGE_BANDS * nrows * ncols), num_scenes, sizeof (int));
+        buf = malloc ((TOTAL_IMAGE_BANDS * nrows * ncols * num_scenes * sizeof (int)));
+        if (buf == NULL)
+        {
+            RETURN_ERROR ("Allocating buf memory", FUNC_NAME, FAILURE);
+        }
+    
+    
+        /**************************************************************/
+        /*                                                            */
+        /* Create the Input metadata structure.                       */
+        /*                                                            */
+        /**************************************************************/
+
+        meta = (Input_meta_t *)malloc(sizeof(Input_meta_t));
+        if (meta == NULL) 
+        {
+            RETURN_ERROR("allocating Input data structure", FUNC_NAME, FAILURE);
+        }
+    
+/**************************************************/
+/*                                                */
+/* put all these in a wrapper call like get data  */
+/*                                                */
+/**************************************************/
+
+        /**************************************************************/
+        /*                                                            */
+        /* Get the metadata, all scene metadata are the same for      */
+        /* stacked scenes.                                            */
+        /*                                                            */
+        /**************************************************************/
+
+        status = read_envi_header(data_type, scene_list[0], meta);
+        if (status != SUCCESS)
+        {
+            RETURN_ERROR ("Calling read_envi_header", 
+                          FUNC_NAME, FAILURE);
+        }
+    
+        /******************************************************************/
+        /*                                                                */
+        /* Read the cfmask file first, determine which pixels are valid.  */
+        /*   0: clear                                                     */
+        /*   1: water                                                     */
+        /*   2: cloudShadow                                               */
+        /*   3: snow                                                      */
+        /*   4: cloud                                                     */
+        /* 255: CFMASK_FILL                                               */
+        /*                                                                */
+        /* This will determine whether or not to use this pixel, which    */
+        /* then requires subsequent reading of image bands.               */
+        /*                                                                */
+        /* While reading, update the counters for clear, water, cloud,    */
+        /* and snow, essentially skipping over fill values,               */
+        /* and update the number of "scenes" so that only the data bands  */
+        /* buffer and date information array are filled with values from  */
+        /* from valid "scenes".                                           */
+        /*                                                                */
+        /* Previously, all data was read, then cfmask was checked after   */
+        /* the last loop, and was accidentally checked because the cfmask */
+        /* file just happend to be the last file read.  However, when     */
+        /* checking for valid values of 50 percent or greater the         */
+        /* calculation was done incorecctly, was always zero, so          */
+        /* all cases were passed along to the ccdc algorithm, even if     */
+        /* there were less than 50 percent valid pixels, and sometimes,   */
+        /* even if there was no valid data, or not enough valid data,     */
+        /* which caused data-dependent crashes.                           */
+        /*                                                                */
+        /* Furthermore, FILL_VALUE for cfmask is defined in ccdc.h,       */
+        /* but nowhere for the image bands.  Both should really be read   */
+        /* from the .xml metadata file provided by ESPA, but it is not    */
+        /* populated along with other ARD files, currently. Optionally,   */
+        /* user environment variables could be defined and parsed.        */
+        /*                                                                */
+        /******************************************************************/
+    
+        valid_num_scenes = 0;
+        prev_fmask_buf = 254;
+
+        for (i = 0; i < num_scenes; i++)
+        {
+            status = read_cfmask(i, data_type, scene_list, row, col, nrows, ncols,
+                                 meta->samples, fp_tifs, fp_bip, fmask_buf,
+                                 &prev_wrs_path, &prev_wrs_row, &prev_year,
+                                 &prev_jday, &prev_fmask_buf, &valid_scene_count,
+                                 &swath_overlap_count, valid_scene_list,
+                                 &clr_sum, &water_sum, &shadow_sum, &sn_sum,
+                                 &cloud_sum, &fill_sum, &all_sum, updated_fmask_buf,
+                                 updated_sdate_array, sdate, &valid_num_scenes); // offsets
+
+            if (fmask_buf[i] < CFMASK_FILL)
+            {
+                /******************************************************/
+                /*                                                    */
+                /* Valid pixel according to cfmask, so read the image */
+                /* bands and update image values buffer.              */
+                /*                                                    */
+                /******************************************************/
+
+                if (debug)
+                {
+                    printf("%d %d %d ", i, valid_scene_count -1, updated_sdate_array[valid_scene_count - 1]);
+                }
+                if (strcmp(data_type, "tifs") == 0)
+                {
+                    status = read_tifs(valid_scene_list[valid_scene_count - 1],
+                                       fp_tifs, (valid_scene_count - 1), row, col,
+                                       nrows, ncols, meta->samples, debug, buf); // offsets
+                    if (status != SUCCESS)
+                    {
+                        RETURN_ERROR ("Calling read_tifs", 
+                                      FUNC_NAME, FAILURE);
+                    }
+                }
+                else if ((strcmp(data_type, "bip")       == 0) ||
+                         (strcmp(data_type, "bip_lines") == 0))
+                {
+                    printf (" reading bip ");
+                    status = read_bip(valid_scene_list[valid_scene_count - 1],
+                                      fp_bip, (valid_scene_count - 1), row, col,
+                                      nrows, ncols, meta->samples, buf); // offsets
+                }
+//                else if (strcmp(data_type, "bip_lines") == 0)
+//                {
+//                    printf ("reading bip lines");
+//                    status = read_bip_lines(valid_scene_list[valid_scene_count - 1],
+//                                            fp_bip, (valid_scene_count - 1), row, col,
+//                                            meta->samples, buf);
+//                }
+
+                if (debug)
+                {
+                    printf("%d\n", updated_fmask_buf[valid_scene_count - 1]);
+                }
+
+            }
+
+        }
+
+    } // end of elseif stdin bracket, meaning not stdin, read cfmask and image files
+
+    if ((verbose) && (!std_in))
+    {
+        /**************************************************************/
+        /*                                                            */
+        /* Print some info to show how the input metadata works.      */
+        /*                                                            */
+        /**************************************************************/
+
+        printf ("DEBUG: Number of input lines: %d\n", meta->lines);
+        printf ("DEBUG: Number of input samples: %d\n", meta->samples);
+        printf ("DEBUG: UL_MAP_CORNER: %d, %d\n", meta->upper_left_x,
+                meta->upper_left_y);
+        printf ("DEBUG: ENVI data type: %d\n", meta->data_type);
+        printf ("DEBUG: ENVI byte order: %d\n", meta->byte_order);
+        printf ("DEBUG: UTM zone number: %d\n", meta->utm_zone);
+        printf ("DEBUG: Pixel size: %d\n", meta->pixel_size);
+        printf ("DEBUG: Envi save format: %s\n", meta->interleave);
+        printf ("DEBUG: Number of pixel overlap scenes removed: %d\n", swath_overlap_count);
+
+        /**************************************************************/
+        /*                                                            */
+        /* Log the time to denote end of I/O, algorithm to follow.    */
+        /*                                                            */
+        /**************************************************************/
+
+        snprintf (msg_str, sizeof(msg_str), "CCDC read_time=%s\n", ctime (&now));
+        LOG_MESSAGE (msg_str, FUNC_NAME);
+
+    }
+
+
+    /******************************************************************/
+    /*                                                                */
+    /* Allocate memory for rec_cg.                                    */ 
+    /*                                                                */
+    /******************************************************************/
+
+    rec_cg = malloc(MAX_NUM_FC * sizeof(Output_t));
+    if (rec_cg == NULL)
+    {
+        RETURN_ERROR("ERROR allocating rec_cg memory", FUNC_NAME, FAILURE);
+    }
+
         clrx = malloc(num_scenes * sizeof(int));
         if (clrx == NULL)
         {
             RETURN_ERROR("ERROR allocating clrx memory", FUNC_NAME, FAILURE);
-        }
-    
-        fmask_buf = malloc(num_scenes * sizeof(unsigned char));
-        if (fmask_buf == NULL)
-        {
-            RETURN_ERROR("ERROR allocating fmask_buf memory", FUNC_NAME, FAILURE);
         }
     
         id_range = (int *)calloc(num_scenes, sizeof(int));
@@ -661,854 +866,2041 @@ int main (int argc, char *argv[])
         {
             RETURN_ERROR ("Allocating temp_v_dif memory",FUNC_NAME, FAILURE);
         }
-    
-        buf = (int **) allocate_2d_array (TOTAL_BANDS, num_scenes, sizeof (int));
-        if (buf == NULL)
-        {
-            RETURN_ERROR ("Allocating buf memory", FUNC_NAME, FAILURE);
-        }
-    
-        /**************************************************************/
-        /*                                                            */
-        /* Create the Input metadata structure.                       */
-        /*                                                            */
-        /**************************************************************/
 
-        meta = (Input_meta_t *)malloc(sizeof(Input_meta_t));
-        if (meta == NULL) 
-        {
-            RETURN_ERROR("allocating Input data structure", FUNC_NAME, FAILURE);
-        }
-    
-/**************************************************/
-/*                                                */
-/* put all these in a wrapper call like get data  */
-/*                                                */
-/**************************************************/
+    for (row_inx = (row - 1), row_count = 0; row_count < nrows; row_count++, row_inx++)
+    {
+      for (col_inx = (col - 1), col_count = 0; col_count < ncols; col_count++, col_inx++)
+      {
+
+        if (debug)
+            printf("row_inx %d col_inx %d\n", row_inx, col_inx);
 
         /**************************************************************/
         /*                                                            */
-        /* Get the metadata, all scene metadata are the same for      */
-        /* stacked scenes.                                            */
+        /* Do the remaining allocations for all buffers/arrays        */
+        /* necessary for the ccdc algorithm, because after filling    */
+        /* the band data arrays here, that will be the next step.     */
         /*                                                            */
         /**************************************************************/
 
-        status = read_envi_header(data_type, scene_list[0], meta);
-        if (status != SUCCESS)
-        {
-            RETURN_ERROR ("Calling read_envi_header", 
-                          FUNC_NAME, FAILURE);
-        }
-    
+
+        /**************************************************************/
+        /*                                                            */
+        /* Clear cfmask pixel value accumulators, then call the       */
+        /* function for totalling cfmask values.                      */
+        /*                                                            */
+        /* All this was done in input.c.  Assume valid 2d arrays for  */
+        /* cfmask and buf already exist. However, we need to          */
+        /* stats to determine whether or not this pixel gets          */
+        /* processed.                                                 */
+        /*                                                            */
+        /* Correct solution is to save these values in read_cfmask.   */
+        /*                                                            */
+        /**************************************************************/
+
+//        clear_sum = 0;
+//        water_sum = 0;
+//        shadow_sum = 0;
+//        cloud_sum = 0;
+//        fill_sum = 0;
+//        clr_sum = 0;
+//        sn_sum = 0;
+//        all_sum = 0;
+//        valid_num_scenes = 0;
+//
+//        for (i = 0; i < valid_num_scenes; i++)
+//        {
+//            status = assign_cfmask_values (fmask_buf[col * valid_num_scenes + i], &clear_sum, // offsets
+//                                           &water_sum, &shadow_sum, &sn_sum,
+//                                           &cloud_sum, &fill_sum, &all_sum);
+//            if (status != SUCCESS)
+//            {
+//                RETURN_ERROR ("Calling assign_cfmask_values", FUNC_NAME, FAILURE);
+//            }
+
+// assume fmask buf and buf are already filled with only valid pixels
+//            if (fmask_buf[col * num_scenes + i] < CFMASK_FILL)
+//            {
+//                all_sum++;
+//                fmask_pix_buf[valid_num_scenes] = fmask_buf[col * num_scenes + i];
+//                sdate_pix[valid_num_scenes] = sdate[i];
+// fix this row col index offsets
+//                for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
+//                    pix_buf[b][valid_num_scenes] = buf[col * TOTAL_BANDS + b][i];
+//                valid_num_scenes++;
+//            }
+//        }
+
         /******************************************************************/
         /*                                                                */
-        /* Read the cfmask file first, determine which pixels are valid.  */
-        /*   0: clear                                                     */
-        /*   1: water                                                     */
-        /*   2: cloudShadow                                               */
-        /*   3: snow                                                      */
-        /*   4: cloud                                                     */
-        /* 255: CFMASK_FILL                                               */
-        /*                                                                */
-        /* This will determine whether or not to use this pixel, which    */
-        /* then requires subsequent reading of image bands.               */
-        /*                                                                */
-        /* While reading, update the counters for clear, water, cloud,    */
-        /* and snow, essentially skipping over fill values,               */
-        /* and update the number of "scenes" so that only the data bands  */
-        /* buffer and date information array are filled with values from  */
-        /* from valid "scenes".                                           */
-        /*                                                                */
-        /* Previously, all data was read, then cfmask was checked after   */
-        /* the last loop, and was accidentally checked because the cfmask */
-        /* file just happend to be the last file read.  However, when     */
-        /* checking for valid values of 50 percent or greater the         */
-        /* calculation was done incorecctly, was always zero, so          */
-        /* all cases were passed along to the ccdc algorithm, even if     */
-        /* there were less than 50 percent valid pixels, and sometimes,   */
-        /* even if there was no valid data, or not enough valid data,     */
-        /* which caused data-dependent crashes.                           */
-        /*                                                                */
-        /* Furthermore, FILL_VALUE for cfmask is defined in ccdc.h,       */
-        /* but nowhere for the image bands.  Both should really be read   */
-        /* from the .xml metadata file provided by ESPA, but it is not    */
-        /* populated along with other ARD files, currently. Optionally,   */
-        /* user environment variables could be defined and parsed.        */
+        /* Percent of clear pixels: clear (0) or water (1).               */    
         /*                                                                */
         /******************************************************************/
-    
-        valid_num_scenes = 0;
-        prev_fmask_buf = 254;
 
-        for (i = 0; i < num_scenes; i++)
-        {
-            status = read_cfmask(i, data_type, scene_list, row, col,
-                                 meta->samples, fp_tifs, fp_bip, fmask_buf,
-                                 &prev_wrs_path, &prev_wrs_row, &prev_year,
-                                 &prev_jday, &prev_fmask_buf, &valid_scene_count,
-                                 &swath_overlap_count, valid_scene_list,
-                                 &clr_sum, &water_sum, &shadow_sum, &sn_sum,
-                                 &cloud_sum, &fill_sum, &all_sum, updated_fmask_buf,
-                                 updated_sdate_array, sdate, &valid_num_scenes);
+        clr_pct = (float) clr_sum / (float) all_sum;
 
-            if (fmask_buf[i] < CFMASK_FILL)
-            {
-                /******************************************************/
-                /*                                                    */
-                /* Valid pixel according to cfmask, so read the image */
-                /* bands and update image values buffer.              */
-                /*                                                    */
-                /******************************************************/
+        /******************************************************************/
+        /*                                                                */
+        /* percent of snow observations (3).                              */
+        /*                                                                */
+        /******************************************************************/
 
-                if (debug)
-                {
-                    printf("%d %d %d", i, valid_scene_count -1, updated_sdate_array[valid_scene_count - 1]);
-                }
-                if (strcmp(data_type, "tifs") == 0)
-                {
-                    status = read_tifs(valid_scene_list[valid_scene_count - 1],
-                                       fp_tifs, (valid_scene_count - 1), row, col,
-                                       meta->samples, debug, buf);
-                    if (status != SUCCESS)
-                    {
-                        RETURN_ERROR ("Calling read_tifs", 
-                                      FUNC_NAME, FAILURE);
-                    }
-                }
-                else if ((strcmp(data_type, "bip")       == 0) ||
-                         (strcmp(data_type, "bip_lines") == 0))
-                {
-                    printf ("reading bip ");
-                    status = read_bip(valid_scene_list[valid_scene_count - 1],
-                                      fp_bip, (valid_scene_count - 1), row, col,
-                                      meta->samples, buf);
-                }
-//                else if (strcmp(data_type, "bip_lines") == 0)
-//                {
-//                    printf ("reading bip lines");
-//                    status = read_bip_lines(valid_scene_list[valid_scene_count - 1],
-//                                            fp_bip, (valid_scene_count - 1), row, col,
-//                                            meta->samples, buf);
-//                }
-
-                if (debug)
-                {
-                    printf("%d\n", updated_fmask_buf[valid_scene_count - 1]);
-                }
-
-            }
-
-        }
-
-    } // end of elseif stdin bracket, meaning not stdin, read cfmask and image files
-
-    if ((verbose) && (!std_in))
-    {
-        /**************************************************************/
-        /*                                                            */
-        /* Print some info to show how the input metadata works.      */
-        /*                                                            */
-        /**************************************************************/
-
-        printf ("DEBUG: Number of input lines: %d\n", meta->lines);
-        printf ("DEBUG: Number of input samples: %d\n", meta->samples);
-        printf ("DEBUG: UL_MAP_CORNER: %d, %d\n", meta->upper_left_x,
-                meta->upper_left_y);
-        printf ("DEBUG: ENVI data type: %d\n", meta->data_type);
-        printf ("DEBUG: ENVI byte order: %d\n", meta->byte_order);
-        printf ("DEBUG: UTM zone number: %d\n", meta->utm_zone);
-        printf ("DEBUG: Pixel size: %d\n", meta->pixel_size);
-        printf ("DEBUG: Envi save format: %s\n", meta->interleave);
-        printf ("DEBUG: Number of pixel overlap scenes removed: %d\n", swath_overlap_count);
-
-        /**************************************************************/
-        /*                                                            */
-        /* Log the time to denote end of I/O, algorithm to follow.    */
-        /*                                                            */
-        /**************************************************************/
-
-        snprintf (msg_str, sizeof(msg_str), "CCDC read_time=%s\n", ctime (&now));
-        LOG_MESSAGE (msg_str, FUNC_NAME);
-
-    }
-
-    /******************************************************************/
-    /*                                                                */
-    /* Percent of clear pixels: clear (0) or water (1).               */    
-    /*                                                                */
-    /******************************************************************/
-
-    clr_pct = (float) clr_sum / (float) all_sum * 100;
-
-    /******************************************************************/
-    /*                                                                */
-    /* percent of snow observations (3).                              */
-    /*                                                                */
-    /******************************************************************/
-
-    if ((clr_sum + sn_sum) != 0)
-        sn_pct =  (float) sn_sum / (float)(clr_sum + sn_sum); 
-    else
-        sn_pct = (float)sn_sum;
-
-    if (verbose)
-    {
-        printf("  Number inputs specified      = %d\n", inputs_specified);
-        printf("  Number of non-overlap pixels = %d\n", (inputs_specified - swath_overlap_count));
-        printf("  Number of fill (255)  pixels = %d\n", fill_sum);
-        printf("  Number of non-fill    pixels = %d\n", all_sum);
-        printf("  Number of clear  (0)  pixels = %d\n", clr_sum);
-        printf("  Number of water  (1)  pixels = %d\n", water_sum);
-        printf("  Number of shadow (2)  pixels = %d\n", shadow_sum);
-        printf("  Number of snow   (3)  pixels = %d\n", sn_sum);
-        printf("  Number of cloud  (4)  pixels = %d\n", cloud_sum);
-        printf("  Number of clear+water pixels = %d\n", clr_sum);
-        printf("  Percent of clear pixels      = %f (of non-fill pixels)\n", clr_pct);
-        printf("  Percent of clear pixels      = %f (of non-fill, non-cloud, non-shadow pixels)\n",
-               (float) clr_sum / (float) (clr_sum + sn_sum) * 100);
-        printf("  Percent of snow  pixels      = %f (of non-fill, non-cloud, non-shadow pixels)\n", (sn_pct * 100));
-    }
-
-    /******************************************************************/
-    /*                                                                */
-    // if clr pct less than 50, return error, however, this syntax
-    // composition of this statement is invalid, and all tests pass, so
-    // remove it..
-    //if (clr_sum < (int) (0.5 * valid_num_scenes))
-    // bdavis 
-    // 20160211, per zhezhu, now that we are processing from gridded
-    // inputs, everything is pixel-based, not scene-based, so the
-    // algorithm itslef can determine whether there are enough pixels
-    // to make a judgement.
-    /*
-    if (clr_sum < (int) (0.5 * all_sum))
-        {
-            RETURN_ERROR ("Not enough clear-sky pixels", FUNC_NAME, FAILURE);
-        }
-     */
-
-    // bdavis 
-    // not sure what this means:
-    /* CHANGE: need change back to 0-6 from 1-7 if original 
-       inputs are used ???????? */
-    /* pixel value ranges should follow physical rules */
-    /*                                                                */
-    /******************************************************************/
-
-    for (i = 0; i < valid_num_scenes; i++)
-    { 
-        /**************************************************************/
-        /*                                                            */
-        /* Convert Kelvin to Celsius (for new espa data).             */
-        /*                                                            */
-        /**************************************************************/
-
-        if (buf[6][i] != -9999)
-            buf[6][i] = (int16)(buf[6][i] * 10 - 27315);
-
-        if ((buf[0][i] > 0) && (buf[0][i] < 10000) &&
-            (buf[1][i] > 0) && (buf[1][i] < 10000) &&
-            (buf[2][i] > 0) && (buf[2][i] < 10000) &&
-            (buf[3][i] > 0) && (buf[3][i] < 10000) &&
-            (buf[4][i] > 0) && (buf[4][i] < 10000) &&
-            (buf[5][i] > 0) && (buf[5][i] < 10000) &&
-            (buf[6][i] > -9320) && (buf[6][i] < 7070))
-	{
-            id_range[i] = 1;
-	}
+        if ((clr_sum + sn_sum) != 0)
+            sn_pct =  (float) sn_sum / (float)(clr_sum + sn_sum); 
         else
-	{
-            id_range[i] = 0;
-	}
-    }
+            sn_pct = (float)sn_sum;
 
-
-    /******************************************************************/
-    /*                                                                */
-    /* Allocate memory for rec_cg.                                    */ 
-    /*                                                                */
-    /******************************************************************/
-
-    rec_cg = malloc(NUM_FC * sizeof(Output_t));
-    if (rec_cg == NULL)
-    {
-        RETURN_ERROR("ERROR allocating rec_cg memory", FUNC_NAME, FAILURE);
-    }
-
-    /******************************************************************/
-    /*                                                                */
-    /* Fit permanent snow observations.                               */
-    /*                                                                */
-    /******************************************************************/
-
-    if (clr_pct < T_CLR)
-    {
-        if (sn_pct > T_SN)
+        if (verbose)
         {
-            n_sn = 0;
+            printf("  Number inputs specified      = %d\n", inputs_specified);
+            printf("  Number of non-overlap pixels = %d\n", (inputs_specified - swath_overlap_count));
+            printf("  Number of fill (255)  pixels = %d\n", fill_sum);
+            printf("  Number of non-fill    pixels = %d\n", all_sum);
+            printf("  Number of clear  (0)  pixels = %d\n", clr_sum);
+            printf("  Number of water  (1)  pixels = %d\n", water_sum);
+            printf("  Number of shadow (2)  pixels = %d\n", shadow_sum);
+            printf("  Number of snow   (3)  pixels = %d\n", sn_sum);
+            printf("  Number of cloud  (4)  pixels = %d\n", cloud_sum);
+            printf("  Number of clear+water pixels = %d\n", clr_sum);
+            printf("  Percent of clear pixels      = %f (of non-fill pixels)\n", clr_pct);
+            printf("  Percent of clear pixels      = %f (of non-fill, non-cloud, non-shadow pixels)\n",
+                   (float) clr_sum / (float) (clr_sum + sn_sum) * 100);
+            printf("  Percent of snow  pixels      = %f (of non-fill, non-cloud, non-shadow pixels)\n", (sn_pct * 100));
+        }
 
-            /**********************************************************/
-            /*                                                        */
-            /* Snow observations are "good" now.                      */
-            /*                                                        */
-            /**********************************************************/
+        for (scene_inx = 0; scene_inx < valid_num_scenes; scene_inx++)
+        { 
+            /**************************************************************/
+            /*                                                            */
+            /* pixel value ranges should follow physical rules.i          */
+            /* Convert Kelvin to Celsius (for new espa data).             */
+            /*                                                            */
+            /**************************************************************/
+// offsets
+            //if (buf[6][i] != -9999)
+            //offset = (((row_inx * meta->samples * valid_num_scenes * TOTAL_IMAGE_BANDS) +
+            //            (col_inx * valid_num_scenes * TOTAL_IMAGE_BANDS)) +
+            //             scene_inx * TOTAL_IMAGE_BANDS);
+            offset = (((row_count * meta->samples * valid_num_scenes * TOTAL_IMAGE_BANDS) +
+                        (col_count * valid_num_scenes * TOTAL_IMAGE_BANDS)) +
+                         scene_inx * TOTAL_IMAGE_BANDS);
+            if (buf[offset + THERMAL_BAND] != -9999)
+                buf[offset + THERMAL_BAND] = (int16)(buf[offset + THERMAL_BAND] * 10 - 27315);
 
-            for (i = 0; i < valid_num_scenes; i++)
-            { 
-	        if (((updated_fmask_buf[i] == CFMASK_SNOW) || (updated_fmask_buf[i] < 2)) 
-                     && id_range[i] == 1)
-                {
-                    clrx[n_sn] = updated_sdate_array[i];
-                    for (k = 0; k < TOTAL_IMAGE_BANDS; k++)
-		    {
-         	        clry[k][n_sn] = (float)buf[k][i];
-		    }
-                    n_sn++;
-                }
-            }  
-            end = n_sn;
-
-            /**********************************************************/
-            /*                                                        */
-            /* Remove repeated ids.                                   */
-            /*                                                        */
-            /**********************************************************/
-
-            matlab_unique(clrx, clry, n_sn, &end);
-
-            if (n_sn < N_TIMES * MIN_NUM_C) // not enough snow pixels
+            if ((buf[offset + 0] > 0)     && (buf[offset + 0] < 10000) &&
+                (buf[offset + 1] > 0)     && (buf[offset + 1] < 10000) &&
+                (buf[offset + 2] > 0)     && (buf[offset + 2] < 10000) &&
+                (buf[offset + 3] > 0)     && (buf[offset + 3] < 10000) &&
+                (buf[offset + 4] > 0)     && (buf[offset + 4] < 10000) &&
+                (buf[offset + 5] > 0)     && (buf[offset + 5] < 10000) &&
+                (buf[offset + 6] > -9320) && (buf[offset + 6] < 7070))
             {
-                RETURN_ERROR ("Not enough good snow observations\n", 
-                     FUNC_NAME, FAILURE);
+                id_range[i] = 1;
             }
-
-            /**********************************************************/
-            /*                                                        */
-            /* Start model fit for snow persistent pixels.            */
-            /*                                                        */
-            /**********************************************************/
-
-            if (verbose)
-                printf ("Fit permanent snow observations, now pixel = %f\n", 
-                       100.0 * sn_pct); 
-
-            i_start = 1; /* the first observation for TSFit */
-
-            /**********************************************************/
-            /*                                                        */
-            /* Treat saturated and unsaturated pixels differently.    */
-            /*                                                        */
-            /**********************************************************/
-
-            for (i = 0; i < end; i++)
+            else
             {
+                id_range[i] = 0;
+            }
+        }
+
+        /**************************************************************/
+        /*                                                            */
+        /* Initilialize rec_cg                                        */
+        /*                                                            */
+        /**************************************************************/
+
+        rec_cg[0].t_break = 0;
+
+        /******************************************************************/
+        /*                                                                */
+        /* Fit permanent snow observations.                               */
+        /*                                                                */
+        /******************************************************************/
+
+        if (clr_pct < T_CLR)
+        {
+            if (sn_pct > T_SN)
+            {
+                n_sn = 0;
+
+                /**********************************************************/
+                /*                                                        */
+                /* Snow observations are "good" now.                      */
+                /*                                                        */
+                /**********************************************************/
+
+                for (scene_inx = 0; scene_inx < valid_num_scenes; scene_inx++)
+                { 
+                    offset = (((row_inx * meta->samples) + 
+                               (col_inx * TOTAL_BANDS))  +
+                                scene_inx);
+    	            if (((updated_fmask_buf[scene_inx] == CFMASK_SNOW) || 
+                         (updated_fmask_buf[scene_inx] < 2))           &&
+                          id_range[scene_inx] == 1)
+                    {
+                        clrx[n_sn] = updated_sdate_array[scene_inx];
+                        for (k = 0; k < TOTAL_IMAGE_BANDS; k++)
+                        {
+                 	    clry[k][n_sn] = (float)buf[offset + k]; // offsets
+                        }
+                        n_sn++;
+                    }
+                }  
+                end = n_sn;
+
+                if (n_sn < N_TIMES * MIN_NUM_C) // not enough snow pixels
+                {
+                    RETURN_ERROR ("Not enough good snow observations\n", 
+                         FUNC_NAME, FAILURE);
+                }
+
+                /**********************************************************/
+                /*                                                        */
+                /* Remove repeated ids.                                   */
+                /*                                                        */
+                /**********************************************************/
+
+                matlab_unique(clrx, clry, n_sn, &end);
+
+                /**********************************************************/
+                /*                                                        */
+                /* Start model fit for snow persistent pixels.            */
+                /*                                                        */
+                /**********************************************************/
+
+                if (verbose)
+                    printf ("Fit permanent snow observations, now pixel = %f\n", 
+                            100.0 * sn_pct); 
+
+                i_start = 1; /* the first observation for TSFit */
+
+                /**********************************************************/
+                /*                                                        */
+                /* Treat saturated and unsaturated pixels differently.    */
+                /*                                                        */
+                /**********************************************************/
+
                 for (k = 0; k < TOTAL_IMAGE_BANDS; k++)
                 {
-         	    i_span = 0;
-                    if (k != TOTAL_IMAGE_BANDS - 1) // for optical bands
+                    i_span = 0;
+                    for (i = 0; i < end; i++)
                     {
-                        if (clry[i][k] > 0.0 && clry[i][k] < 10000.0)
+                        if (k != TOTAL_IMAGE_BANDS - 1) // for optical bands
                         {
-                            clrx[i_span] = clrx[i];
-                            clry[i_span][k] = clry[i][k];
-                            i_span++;
-                        }
+                            if (clry[i][k] > 0.0 && clry[i][k] < 10000.0)
+                            {
+                                clrx[i_span] = clrx[i];
+                                clry[i_span][k] = clry[i][k];
+                                i_span++;
+                            }
 
-                        if (i_span < MIN_NUM_C * N_TIMES)
-                            fit_cft[i][k] = 10000; // fixed value for saturated pixels
-                        else
-                        {
-                            status = auto_ts_fit(clrx, clry, k, 0, i_span-1, MIN_NUM_C, 
-                                     fit_cft, &rmse[k], temp_v_dif); 
-                            if (status != SUCCESS)  
-                                RETURN_ERROR ("Calling auto_ts_fit1\n", 
-                                       FUNC_NAME, EXIT_FAILURE);
+                            if (i_span < MIN_NUM_C * N_TIMES)
+                                fit_cft[i][k] = 10000; // fixed value for saturated pixels
+                            else
+                            {
+                                status = auto_ts_fit(clrx, clry, k, 0, i_span-1, MIN_NUM_C, 
+                                         fit_cft, &rmse[k], temp_v_dif); 
+                                if (status != SUCCESS)  
+                                    RETURN_ERROR ("Calling auto_ts_fit1\n", 
+                                           FUNC_NAME, EXIT_FAILURE);
 
-                        } 
-                    }
-                    else // for thermal band
-                    {
-                        if (clry[i][k] > -9300.0 && clry[i][k] < 7070.0)
-                        {
-                            clrx[i_span] = clrx[i];
-                            clry[i_span][k] = clry[i][k];
-                            i_span++;
+                            } 
                         }
+                        else // for thermal band
+                        {
+                            if (clry[i][k] > -9300.0 && clry[i][k] < 7070.0)
+                            {
+                                clrx[i_span] = clrx[i];
+                                clry[i_span][k] = clry[i][k];
+                                i_span++;
+                            }
                             
-                        status = auto_ts_fit(clrx, clry, k, 0, i_span-1, MIN_NUM_C, fit_cft, 
-                                 &rmse[k], temp_v_dif); 
-                        if (status != SUCCESS)  
-                            RETURN_ERROR ("Calling auto_ts_fit2\n", 
-                                  FUNC_NAME, EXIT_FAILURE);
-		    }
+                            status = auto_ts_fit(clrx, clry, k, 0, i_span-1, MIN_NUM_C, fit_cft, 
+                                     &rmse[k], temp_v_dif); 
+                            if (status != SUCCESS)  
+                                RETURN_ERROR ("Calling auto_ts_fit2\n", 
+                                      FUNC_NAME, EXIT_FAILURE);
+                        }
+                    }
+                }
+
+                /******************************************************/
+                /*                                                    */
+                /* NUM of Fitted Curves (num_fc)                      */
+                /*                                                    */
+                /******************************************************/
+
+                num_fc++;
+                if (num_fc >= MAX_NUM_FC)
+                {
+                    /**************************************************/
+                    /*                                                */
+                    /* Reallocate memory for rec_cg                   */
+                    /*                                                */
+                    /**************************************************/
+                    rec_cg = realloc(rec_cg, (num_fc + 1) * sizeof(Output_t));
+                    if (rec_cg == NULL)
+                    {
+                        RETURN_ERROR("ERROR allocating rec_cg memory",
+                                     FUNC_NAME, FAILURE);
+                    }
+                }
+
+                /**********************************************************/
+                /*                                                        */
+                /* Update information at each iteration                   */
+                /* Record time of curve start, end.                       */
+                /*                                                        */
+                /**********************************************************/
+
+                rec_cg[num_fc].t_start = clrx[i_start-1]; 
+                rec_cg[num_fc].t_end = clrx[end-1]; 
+
+                /**********************************************************/
+                /*                                                        */
+                /* No break at the moment.                                */
+                /*                                                        */
+                /**********************************************************/
+
+                rec_cg[num_fc].t_break = 0; 
+
+                /**********************************************************/
+                /*                                                        */
+                /* Record postion of the pixel.                           */
+                /*                                                        */
+                /**********************************************************/
+
+                rec_cg[num_fc].pos = (row) * ncols + col_inx + 1; 
+
+                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                {
+                    for (k = 0; k < MAX_NUM_C; k++)
+                    {
+                        /**************************************************/
+                        /*                                                */
+                        /* Record fitted coefficients.                    */
+                        /*                                                */
+                        /**************************************************/
+
+                        rec_cg[num_fc].coefs[i_b][k] = fit_cft[i_b][k];
+                    }
+
+                    /******************************************************/
+                    /*                                                    */
+                    /* Record rmse of the pixel.                          */
+                    /*                                                    */
+                    /******************************************************/
+
+                    rec_cg[num_fc].rmse[i_b] = rmse[i_b]; 
+                }
+
+                /**********************************************************/
+                /*                                                        */
+                /* Record change probability, number of observations.     */
+                /*                                                        */
+                /**********************************************************/
+
+                rec_cg[num_fc].change_prob = 0.0; 
+                rec_cg[num_fc].num_obs = n_sn; 
+                rec_cg[num_fc].category = 50 + MIN_NUM_C; /* snow pixel */
+
+                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                {
+                    /******************************************************/
+                    /*                                                    */
+                    /* Record change magnitude.                           */ 
+                    /*                                                    */
+                    /******************************************************/
+
+                    rec_cg[num_fc].magnitude[i_b] = 0.0; 
+                }
+
+            }  // if sn_pct > T_SN
+
+            else
+
+            {
+
+                /**********************************************************/
+                /*                                                        */
+                /* No change detection for clear observations, backup     */
+                /* algorithm.                                             */
+                /*                                                        */
+                /**********************************************************/
+
+                n_clr = 0;
+
+                for (scene_inx = 0; scene_inx < valid_num_scenes; scene_inx++)
+                { 
+                    offset = (((row_inx * meta->samples) + 
+                               (col_inx * TOTAL_BANDS))  +
+                                scene_inx);
+                    if (id_range[scene_inx] == 1)
+                    {
+                        clrx[n_clr] = updated_sdate_array[scene_inx];
+                        for (k = 0; k < TOTAL_IMAGE_BANDS; k++)
+                            clry[k][n_clr] = (float)buf[offset + k]; // offsets
+                        n_clr++;
+                    }   
+                }
+                end = n_clr;
+
+                /**********************************************************/
+                /*                                                        */
+                /* Remove repeated ids.                                   */
+                /*                                                        */
+                /**********************************************************/
+
+                matlab_unique(clrx, clry, n_clr, &end);
+
+                /**********************************************************/
+                /*                                                        */
+                /* Start model fit for clear persistent pixels.           */
+                /*                                                        */
+                /**********************************************************/
+
+                if (verbose)
+                    printf ("Fmask failed, clear pixel = %f\n", 100.0 * clr_pct); 
+
+                n_clr = 0;
+                float band2_median; // probably not good practice to declare here....
+                quick_sort_float(clry[1], 0, end - 1);
+                matlab_2d_float_median(clry, 1, end, &band2_median);
+
+                for (i = 0; i < end; i++)
+                {
+                    if (clry[1][i] < (band2_median + 400.0))
+                    {
+                        clrx[n_clr] = clrx[i];
+                        for (k = 0; k < TOTAL_IMAGE_BANDS; k++)
+                        { 
+                            clry[k][n_clr] = clry[k+1][i]; 
+                        }
+                        n_clr++;
+                    }
+                }
+                end = n_clr;
+
+                /**********************************************************/
+                /*                                                        */
+                /* The first observation for TSFit.                       */
+                /*                                                        */
+                /**********************************************************/
+
+                i_start = 1; /* the first observation for TSFit */
+
+                if (n_clr < N_TIMES * MIN_NUM_C)
+                {
+                    continue;
+                }
+                else
+                {
+                    for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                    {
+                        status = auto_ts_fit(clrx, clry, i_b, 0, end-1, MIN_NUM_C, 
+                                             fit_cft, &rmse[k], temp_v_dif); 
+                        if (status != SUCCESS)
+                        {  
+                            RETURN_ERROR ("Calling auto_ts_fit for clear persistent pixels\n", 
+                                          FUNC_NAME, FAILURE);
+                        }
+                    }
+                }
+
+                /******************************************************/
+                /*                                                    */
+                /* NUM of Fitted Curves (num_fc)                      */
+                /*                                                    */
+                /******************************************************/
+
+                num_fc++;
+                if (num_fc >= MAX_NUM_FC)
+                {
+                    /**************************************************/
+                    /*                                                */
+                    /* Reallocate memory for rec_cg                   */
+                    /*                                                */
+                    /**************************************************/
+                    rec_cg = realloc(rec_cg, (num_fc + 1) * sizeof(Output_t));
+                    if (rec_cg == NULL)
+                    {
+                        RETURN_ERROR("ERROR allocating rec_cg memory",
+                                     FUNC_NAME, FAILURE);
+                    }
+                }
+
+                /**********************************************************/
+                /*                                                        */
+                /* Update information at each iteration.                  */
+                /* Record time of curve start, time of curve end.         */
+                /*                                                        */
+                /**********************************************************/
+
+                rec_cg[num_fc].t_start = clrx[i_start-1]; 
+                rec_cg[num_fc].t_end = clrx[end-1]; 
+
+                /**********************************************************/
+                /*                                                        */
+                /* No break at the moment.                                */
+                /*                                                        */
+                /**********************************************************/
+
+                rec_cg[num_fc].t_break = 0; 
+
+                /**********************************************************/
+                /*                                                        */
+                /* Record postion of the pixel.                           */
+                /*                                                        */
+                /**********************************************************/
+
+                rec_cg[num_fc].pos = (row-1) * ncols + col_inx + 1; 
+
+                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                {
+                    for (k = 0; k < MAX_NUM_C; k++)
+                    {
+                        /**************************************************/
+                        /*                                                */
+                        /* Record fitted coefficients.                    */
+                        /*                                                */
+                        /**************************************************/
+
+                        rec_cg[num_fc].coefs[i_b][k] = fit_cft[i_b][k];
+                    }
+
+                    /******************************************************/
+                    /*                                                    */
+                    /* Record rmse of the pixel.                          */
+                    /*                                                    */
+                    /******************************************************/
+
+                    rec_cg[num_fc].rmse[i_b] = rmse[i_b]; 
+                }
+
+                /**********************************************************/
+                /*                                                        */
+                /* Record change probability, number of observations,     */
+                /* fit category.                                          */
+                /*                                                        */
+                /**********************************************************/
+                rec_cg[num_fc].change_prob = 0.0; 
+                rec_cg[num_fc].num_obs = n_clr; 
+                rec_cg[num_fc].category = 40 + MIN_NUM_C; 
+
+                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                {
+                    /******************************************************/
+                    /*                                                    */
+                    /* Record change magnitude.                           */ 
+                    /*                                                    */
+                    /******************************************************/
+                    rec_cg[num_fc].magnitude[i_b] = 0.0; 
                 }
             }
-
-            /**********************************************************/
-            /*                                                        */
-            /*                                                        */
-            /**********************************************************/
-
-            rec_cg[num_fc].t_start = clrx[i_start-1]; 
-            rec_cg[num_fc].t_end = clrx[end-1]; 
-
-            /**********************************************************/
-            /*                                                        */
-            /* No break at the moment.                                */
-            /*                                                        */
-            /**********************************************************/
-
-            rec_cg[num_fc].t_break = 0; 
-
-            /**********************************************************/
-            /*                                                        */
-            /* Record postion of the pixel.                           */
-            /*                                                        */
-            /**********************************************************/
-
-            rec_cg[num_fc].pos.row = row; 
-            rec_cg[num_fc].pos.col = col; 
-
-            for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-            {
-                for (k = 0; k < MAX_NUM_C; k++)
-		{
-                    /**************************************************/
-                    /*                                                */
-                    /* Record fitted coefficients.                    */
-                    /*                                                */
-                    /**************************************************/
-
-                    rec_cg[num_fc].coefs[i_b][k] = fit_cft[i_b][k];
-		}
-
-                /******************************************************/
-                /*                                                    */
-                /* Record rmse of the pixel.                          */
-                /*                                                    */
-                /******************************************************/
-
-                rec_cg[num_fc].rmse[i_b] = rmse[i_b]; 
-            }
-
-            /**********************************************************/
-            /*                                                        */
-            /* Record change probability, number of observations.     */
-            /*                                                        */
-            /**********************************************************/
-
-            rec_cg[num_fc].change_prob = 0.0; 
-            rec_cg[num_fc].num_obs = n_sn; 
-            rec_cg[num_fc].category = 50 + MIN_NUM_C; /* snow pixel */
-
-            for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-            {
-                /******************************************************/
-                /*                                                    */
-                /* Record change magnitude.                           */ 
-                /*                                                    */
-                /******************************************************/
-
-                rec_cg[num_fc].magnitude[i_b] = 0.0; 
-            }
-
-            /**********************************************************/
-            /*                                                        */
-            /* NUM of Fitted Curves (num_fc).                         */
-            /*                                                        */
-            /**********************************************************/
-
-            num_fc++;
-
-	    if (num_fc >= 10)
-	    {
-
-                /******************************************************/
-                /*                                                    */
-                /* Reallocate memory for rec_cg.                      */ 
-                /*                                                    */
-                /******************************************************/
-
-		rec_cg = realloc(rec_cg, (num_fc + 1) * sizeof(Output_t));
-                if (rec_cg == NULL)
-		{
-                    RETURN_ERROR("ERROR allocating rec_cg memory", 
-                                 FUNC_NAME, FAILURE);
-		}
-            }   
-        }  // if sn_pct > T_SN
-
-        else
-
+        }
+        else /* normal CCDC procedure */
         {
-
-            /**********************************************************/
-            /*                                                        */
-            /* Snow observations are "good" now.                      */
-            /*                                                        */
-            /**********************************************************/
+            if (verbose)
+            {
+                printf("Seasonal Snow (Snow < %f)\n", 100.0 * sn_pct);
+                printf("Fmask works, clear pixels (land/water) = %f\n", 100.0 * clr_pct);
+            }
 
             n_clr = 0;
-
-            for (i = 0; i < valid_num_scenes; i++)
+            for (scene_inx = 0; scene_inx < valid_num_scenes; scene_inx++)
             { 
-                if (id_range[i] == 1)
+                offset = (((row_inx * meta->samples) + 
+                           (col_inx * TOTAL_BANDS))  +
+                            scene_inx);
+                if ((updated_fmask_buf[scene_inx] < 2) && (id_range[scene_inx] == 1)) // offsets
                 {
-                    clrx[n_clr] = updated_sdate_array[i];
+                    clrx[n_clr] = updated_sdate_array[scene_inx]; // offsets
                     for (k = 0; k < TOTAL_IMAGE_BANDS; k++)
-                        clry[k][n_clr] = (float)buf[k][i];
+                    {
+                        clry[k][n_clr] = (float)buf[offset + k]; // offsets
+                    }
                     n_clr++;
                 }   
             }
             end = n_clr;
+            if (debug)
+            {
+                printf("end_clr=%d\n",end);
+            }
 
-            /**********************************************************/
-            /*                                                        */
-            /* Remove repeated ids.                                   */
-            /*                                                        */
-            /**********************************************************/
+            /**************************************************************/
+            /*                                                            */
+            /* Remove repeated ids.                                       */
+            /*                                                            */
+            /**************************************************************/
 
             matlab_unique(clrx, clry, n_clr, &end);
 
-            /**********************************************************/
-            /*                                                        */
-            /* Start model fit for clear persistent pixels.           */
-            /*                                                        */
-            /**********************************************************/
+            /**************************************************************/
+            /*                                                            */
+            /* Calculate median variogram.                                */
+            /*                                                            */
+            /**************************************************************/
 
-            printf ("Fmask failed, clear pixel = %f\n", 
-                   100.0 * clr_pct); 
-
-	    n_clr = 0;
-	    float band2_median; // probably not good practice to declare here....
-            quick_sort_float(clry[1], 0, end - 1);
-            matlab_2d_float_median(clry, 1, end, &band2_median);
-
-            n_clr = 0;
-            for (i = 0; i < end; i++)
+            for (k = 0; k < TOTAL_IMAGE_BANDS; k++)
             {
-		if (clry[1][i] < (band2_median + 400.0))
-		{
-        	    clrx[n_clr] = clrx[i];
-                    for (k = 0; k < TOTAL_IMAGE_BANDS; k++)
-                    { 
-         	        clry[k][n_clr] = clry[k+1][i]; 
-		    }
-    		    n_clr++;
-                }
-	    }
-            end = n_clr;
-
-            /**********************************************************/
-            /*                                                        */
-            /* The first observation for TSFit.                       */
-            /*                                                        */
-            /**********************************************************/
-
-            i_start = 1; /* the first observation for TSFit */
-
-            if (n_clr < N_TIMES * MIN_NUM_C)
+                adj_rmse[k] = 0.0;
+            } 
+            status = median_variogram(clry, TOTAL_IMAGE_BANDS, 0, end-1, adj_rmse);
+            if (status != SUCCESS)
             {
-                RETURN_ERROR("Not enough good clear observations\n", 
-                            FUNC_NAME, FAILURE);
-	    }
-            else
-            {
-                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                {
-                    status = auto_ts_fit(clrx, clry, i_b, 0, end-1, MIN_NUM_C, 
-                                         fit_cft, &rmse[k], temp_v_dif); 
-                    if (status != SUCCESS)
-		    {  
-                        RETURN_ERROR ("Calling auto_ts_fit for clear persistent pixels\n", 
-                                      FUNC_NAME, FAILURE);
-		    }
-		}
+                RETURN_ERROR("ERROR calling median_variogram routine", FUNC_NAME, 
+                             FAILURE);
             }
 
-            /**********************************************************/
-            /*                                                        */
-            /* Update information at each iteration.                  */
-            /* Record time of curve start, time of curve end.         */
-            /*                                                        */
-            /**********************************************************/
-
-            rec_cg[num_fc].t_start = clrx[i_start-1]; 
-            rec_cg[num_fc].t_end = clrx[end-1]; 
-
-            /**********************************************************/
-            /*                                                        */
-            /* No break at the moment.                                */
-            /*                                                        */
-            /**********************************************************/
-
-            rec_cg[num_fc].t_break = 0; 
-
-            /**********************************************************/
-            /*                                                        */
-            /* Record postion of the pixel.                           */
-            /*                                                        */
-            /**********************************************************/
-
-            rec_cg[num_fc].pos.row = row; 
-            rec_cg[num_fc].pos.col = col; 
-
-            for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+            if ((!std_out) && (debug))
             {
-                for (k = 0; k < MAX_NUM_C; k++)
-		{
-                    /**************************************************/
-                    /*                                                */
-                    /* Record fitted coefficients.                    */
-                    /*                                                */
-                    /**************************************************/
-
-                    rec_cg[num_fc].coefs[i_b][k] = fit_cft[i_b][k];
-		}
-
-                /******************************************************/
-                /*                                                    */
-                /* Record rmse of the pixel.                          */
-                /*                                                    */
-                /******************************************************/
-
-                rec_cg[num_fc].rmse[i_b] = rmse[i_b]; 
+                for (k = 0; k < TOTAL_IMAGE_BANDS; k++)
+                    printf("k,adj_rmse[k]=%d,%f\n",k,adj_rmse[k]);
             }
 
+            /**************************************************************/
+            /*                                                            */
+            /* Start with mininum requirement of clear obs.               */
+            /*                                                            */
+            /**************************************************************/
+
+            i = N_TIMES * MIN_NUM_C;
+
+            /**************************************************************/
+            /*                                                            */
+            /* The first observation for TSFit.                           */
+            /*                                                            */
+            /**************************************************************/
+
+            i_start = 1; 
+
+            /**************************************************************/
+            /*                                                            */
+            /* Record the start of the model initialization               */
+            /*     (0=>initial;1=>done)                                   */
+            /*                                                            */
+            /**************************************************************/
+
+            bl_train = 0;
+
             /**********************************************************/
             /*                                                        */
-            /* Record change probability, number of observations,     */
-            /* fit category.                                          */
-            /*                                                        */
-            /**********************************************************/
-            rec_cg[num_fc].change_prob = 0.0; 
-            rec_cg[num_fc].num_obs = n_clr; 
-            rec_cg[num_fc].category = 40 + MIN_NUM_C; 
-
-            for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-	    {
-                /******************************************************/
-                /*                                                    */
-                /* Record change magnitude.                           */ 
-                /*                                                    */
-                /******************************************************/
-                rec_cg[num_fc].magnitude[i_b] = 0.0; 
-	    }
-
-            /**********************************************************/
-            /*                                                        */
-            /* NUM of Fitted Curves (num_fc).                         */
+            /* NUM of Fitted Curves (num_fc)                          */
             /*                                                        */
             /**********************************************************/
 
-            num_fc++;   
-
-       	    if (num_fc >= 10)
-	    {
-                /******************************************************/
-                /*                                                    */
-                /* Reallocate memory for rec_cg.                      */ 
-                /*                                                    */
-                /******************************************************/
-
+            num_fc++;
+            if (num_fc >= MAX_NUM_FC)
+            {
+                /* Reallocate memory for rec_cg */
                 rec_cg = realloc(rec_cg, (num_fc + 1) * sizeof(Output_t));
                 if (rec_cg == NULL)
-		{
-                    RETURN_ERROR("ERROR allocating rec_cg memory", 
-                                 FUNC_NAME, FAILURE);
-		}
-            }
-        }
-    }
-    else /* clear land or water pixels */
-    {
-        if (verbose)
-        {
-            printf("Seasonal Snow (Snow < %f)\n", 100.0 * sn_pct);
-            printf("Fmask works, clear pixels (land/water) = %f\n", clr_pct);
-        }
-
-        n_clr = 0;
-        for (i = 0; i < valid_num_scenes; i++)
-        { 
-            if ((updated_fmask_buf[i] < 2) && (id_range[i] == 1))
-            {
-                clrx[n_clr] = updated_sdate_array[i];
-                for (k = 0; k < TOTAL_IMAGE_BANDS; k++)
-		{
-                    clry[k][n_clr] = (float)buf[k][i];
-		}
-                n_clr++;
-            }   
-        }
-        end = n_clr;
-        if (debug)
-        {
-            printf("end_clr=%d\n",end);
-        }
-
-        /**************************************************************/
-        /*                                                            */
-        /* Remove repeated ids.                                       */
-        /*                                                            */
-        /**************************************************************/
-
-        matlab_unique(clrx, clry, n_clr, &end);
-
-        /**************************************************************/
-        /*                                                            */
-        /* Calculate median variogram.                                */
-        /*                                                            */
-        /**************************************************************/
-
-	for (k = 0; k < TOTAL_IMAGE_BANDS; k++)
-	{
-            adj_rmse[k] = 0.0;
-	} 
-        status = median_variogram(clry, TOTAL_IMAGE_BANDS, 0, end-1, adj_rmse);
-        if (status != SUCCESS)
-	{
-            RETURN_ERROR("ERROR calling median_variogram routine", FUNC_NAME, 
-                         FAILURE);
-	}
-
-        if (!std_out)
-        {
-            for (k = 0; k < TOTAL_IMAGE_BANDS; k++)
-                printf("k,adj_rmse[k]=%d,%f\n",k,adj_rmse[k]);
-        }
-
-        /**************************************************************/
-        /*                                                            */
-        /* Start with mininum requirement of clear obs.               */
-        /*                                                            */
-        /**************************************************************/
-
-        i = N_TIMES * MIN_NUM_C;
-
-        /**************************************************************/
-        /*                                                            */
-        /* The first observation for TSFit.                           */
-        /*                                                            */
-        /**************************************************************/
-
-        i_start = 1; 
-
-        /**************************************************************/
-        /*                                                            */
-        /* Record the start of the model initialization               */
-        /*     (0=>initial;1=>done)                                   */
-        /*                                                            */
-        /**************************************************************/
-
-        bl_train = 0;
-
-        /**************************************************************/
-        /*                                                            */
-        /* Record the num_fc at the beginning of each pixel.          */
-        /*                                                            */
-        /**************************************************************/
-        rec_fc = num_fc;
-
-        /**************************************************************/
-        /*                                                            */
-        /* Record the start of Tmask (0=>initial;1=>done)             */
-        /*                                                            */
-        /**************************************************************/
-
-        bl_tmask = 0;
-
-        /**************************************************************/
-        /*                                                            */
-        /* If verbose, record the start time of just the CDCD         */
-        /*     algorithm.  Up until here, it has all just been        */
-        /*     setting it up......                                    */
-        /*                                                            */
-        /**************************************************************/
-
-        if (verbose)
-        {
-            snprintf (msg_str, sizeof(msg_str), "CCDC init_time=%s\n", ctime (&now));
-            LOG_MESSAGE (msg_str, FUNC_NAME);
-        }
-
-        /**************************************************************/
-        /*                                                            */
-        /* While loop - process til the last clear observation - CONSE*/
-        /*                                                            */
-        /**************************************************************/
-
-        while (i <= end - CONSE)
-        {
-            /**********************************************************/
-            /*                                                        */
-            /* span of "i"                                            */
-            /*                                                        */
-            /**********************************************************/
-
-            i_span = i - i_start + 1;
-
-            /**********************************************************/
-            /*                                                        */
-            /* span of time (num of years)                            */
-            /*                                                        */
-            /**********************************************************/
-            time_span = (float)(clrx[i-1] - clrx[i_start-1]) / NUM_YEARS;
-
-            /**********************************************************/
-            /*                                                        */
-            /* basic requrirements: 1) enough observations;           */
-            /*                      2) enough time                    */
-            /*                                                        */
-            /**********************************************************/
-
-            if ((i_span >= N_TIMES * MIN_NUM_C) && (time_span >= (float)MIN_YEARS))
-            {
-                /******************************************************/
-                /*                                                    */
-                /* Initializing model.                                */
-                /*                                                    */
-                /******************************************************/
-
-                if (bl_train == 0)
                 {
-                    /**************************************************/
-                    /*                                                */
-                    /* Step 1: noise removal.                         */ 
-                    /*                                                */
-                    /**************************************************/
+                    RETURN_ERROR("ERROR allocating rec_cg memory",
+                                 FUNC_NAME, FAILURE);
+                }
+            }
 
-                    status = auto_mask(clrx, clry, i_start-1, i+CONSE-1,
-                                   (float)(clrx[i+CONSE-1]-clrx[i_start-1]) / NUM_YEARS, 
-                                   adj_rmse[1], adj_rmse[4], T_CONST, bl_ids);
-                    if (status != SUCCESS)
-		    {
-                        RETURN_ERROR("ERROR calling auto_mask during model initilization", 
+            /**************************************************************/
+            /*                                                            */
+            /* Record the num_fc at the beginning of each pixel.          */
+            /*                                                            */
+            /**************************************************************/
+            rec_fc = num_fc;
+
+            /**************************************************************/
+            /*                                                            */
+            /* Record the start of Tmask (0=>initial;1=>done)             */
+            /*                                                            */
+            /**************************************************************/
+
+            bl_tmask = 0;
+
+            /**************************************************************/
+            /*                                                            */
+            /* If verbose, record the start time of just the CDCD         */
+            /*     algorithm.  Up until here, it has all just been        */
+            /*     setting it up......                                    */
+            /*                                                            */
+            /**************************************************************/
+
+            if (verbose)
+            {
+                snprintf (msg_str, sizeof(msg_str), "CCDC init_time=%s\n", ctime (&now));
+                LOG_MESSAGE (msg_str, FUNC_NAME);
+            }
+
+            /**************************************************************/
+            /*                                                            */
+            /* While loop - process til the last clear observation - CONSE*/
+            /*                                                            */
+            /**************************************************************/
+
+            while (i <= end - CONSE)
+            {
+                /**********************************************************/
+                /*                                                        */
+                /* span of "i"                                            */
+                /*                                                        */
+                /**********************************************************/
+
+                i_span = i - i_start + 1;
+
+                /**********************************************************/
+                /*                                                        */
+                /* span of time (num of years)                            */
+                /*                                                        */
+                /**********************************************************/
+                time_span = (float)(clrx[i-1] - clrx[i_start-1]) / NUM_YEARS;
+
+                /**********************************************************/
+                /*                                                        */
+                /* basic requrirements: 1) enough observations;           */
+                /*                      2) enough time                    */
+                /*                                                        */
+                /**********************************************************/
+
+                if ((i_span >= N_TIMES * MIN_NUM_C) && (time_span >= (float)MIN_YEARS))
+                {
+                    /******************************************************/
+                    /*                                                    */
+                    /* Initializing model.                                */
+                    /*                                                    */
+                    /******************************************************/
+
+                    if (bl_train == 0)
+                    {
+                        /**************************************************/
+                        /*                                                */
+                        /* Step 1: noise removal.                         */ 
+                        /*                                                */
+                        /**************************************************/
+
+                        status = auto_mask(clrx, clry, i_start-1, i+CONSE-1,
+                                           (float)(clrx[i+CONSE-1]-clrx[i_start-1]) / NUM_YEARS, 
+                                           adj_rmse[1], adj_rmse[4], T_CONST, bl_ids);
+                        if (status != SUCCESS)
+                        {
+                            RETURN_ERROR("ERROR calling auto_mask during model initilization", 
+                                          FUNC_NAME, FAILURE);
+                        }
+
+                        /**************************************************/
+                        /*                                                */
+                        /* Clear the IDs buffers.                         */
+                        /*                                                */
+                        /**************************************************/
+
+                        for (k = 0; k < valid_num_scenes; k++)
+                            ids[k] = 0;
+
+                        /**************************************************/
+                        /*                                                */
+                        /* IDs to be removed.                             */
+                        /*                                                */
+                        /**************************************************/
+
+                        for (k = i_start-1; k < i+CONSE; k++)
+                        {
+                            ids[k-i_start+1] = k;
+                        }
+                        m = 0;
+                        i_span = 0;
+                        for (k = 0; k < i-i_start+1; k++)
+                        {
+                            if (bl_ids[k] == 1) 
+                            {
+                                rm_ids[m] = ids[k];
+                                m++;
+                            }
+                            else
+                                i_span++;  /* update i_span after noise removal */
+                        }
+
+                        rm_ids_len = m;
+
+                        /**************************************************/
+                        /*                                                */
+                        /* Check if there are enough observation.         */
+                        /*                                                */
+                        /**************************************************/
+
+                        if (i_span < (N_TIMES * MIN_NUM_C))
+                        {
+                            /**********************************************/
+                            /*                                            */
+                            /* Move forward to the i+1th clear observation*/
+                            /*                                            */
+                            /**********************************************/
+
+                            i++;
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Not enough clear observations.             */
+                            /*                                            */
+                            /**********************************************/
+
+                            continue;
+                        }
+                        else
+                        {
+    
+                            if (end == 0)
+                                RETURN_ERROR("No available data point", FUNC_NAME, FAILURE);
+
+                            /**************************************************/
+                            /*                                                */
+                            /* Allocate memory for cpx, cpy.                  */
+                            /*                                                */
+                            /**************************************************/
+
+                            cpx = malloc(end * sizeof(int));
+                            if (cpx == NULL)
+                                RETURN_ERROR("ERROR allocating cpx memory", FUNC_NAME, FAILURE);
+
+                            cpy = (float **) allocate_2d_array (TOTAL_IMAGE_BANDS, end,
+                                             sizeof (float));
+                            if (cpy == NULL)
+                            {
+                                RETURN_ERROR ("Allocating cpy memory", FUNC_NAME, FAILURE);
+                            }
+
+                            /**************************************************/
+                            /*                                                */
+                            /* Remove noise pixels between i_start & i.       */
+                            /*                                                */
+                            /**************************************************/
+
+                            m = 0;
+                            for (k = 0, k_new=0; k < end; k++)
+                            {
+                                if (m < rm_ids_len && k == rm_ids[m])
+                                {
+                                    m++;
+                                    continue;
+                                }
+                                cpx[k_new] = clrx[k];
+                                for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
+                                {
+                                    cpy[b][k_new] = clry[b][k];
+                                }
+                                k_new++;
+                            }
+                            end2 = k_new;
+                            end = end2;
+    
+                            /**************************************************/
+                            /*                                                */
+                            /* Record i before noise removal.                 */ 
+                            /* This is very important, ie model is not yet    */
+                            /* initialized.   The multitemporal masking shall */
+                            /* be done again instead of removing outliers  In */
+                            /* every masking.                                 */
+                            /*                                                */
+                            /**************************************************/
+
+                            i_rec = i;
+
+                            /**************************************************/
+                            /*                                                */
+                            /* Update i afer noise removal.                   */
+                            /*     (i_start stays the same).                  */
+                            /*                                                */
+                            /**************************************************/
+
+                            i = i_start + i_span - 1;
+
+                            /**************************************************/
+                            /*                                                */
+                            /* Update span of time (num of years).            */
+                            /*                                                */
+                            /**************************************************/
+
+                            time_span=(cpx[i-1] - cpx[i_start-1]) / NUM_YEARS;
+
+                            /**************************************************/
+                            /*                                                */
+                            /* Check if there is enough time.                 */
+                            /*                                                */
+                            /**************************************************/
+
+                            if (time_span < MIN_YEARS)
+                            {
+                                i = i_rec;   /* keep the original i */
+
+                                /**********************************************/
+                                /*                                            */
+                                /* Move forward to the i+1th clear observation*/
+                                /*                                            */
+                                /**********************************************/
+
+                                i++;        
+                                free(cpx);
+                                status = free_2d_array ((void **) cpy);
+                                if (status != SUCCESS)
+                                {
+                                      RETURN_ERROR ("Freeing memory: cpy\n", 
+                                            FUNC_NAME, FAILURE);
+                                }
+                                continue;    /* not enough time */
+                            }
+                            else
+                            {
+
+                                /**********************************************/
+                                /*                                            */
+                                /* Remove noise in original arrays.           */
+                                /*                                            */
+                                /**********************************************/
+
+                                for (k = 0; k < end; k++)
+                                {
+                                    clrx[k] = cpx[k];
+                                    for (m = 0; m < TOTAL_IMAGE_BANDS; m++)
+                                    {
+                                        clry[m][k] = cpy[m][k];
+                                    }
+                                }
+
+                                free(cpx);
+                                status = free_2d_array ((void **) cpy);
+                                if (status != SUCCESS)
+                                {
+                                    RETURN_ERROR ("Freeing memory: cpy\n", 
+                                         FUNC_NAME, FAILURE);
+                                }
+
+                                /**********************************************/
+                                /*                                            */
+                                /* Step 2) model fitting: initialize model    */
+                                /*         testing variables defining         */
+                                /*         computed variables.                */
+                                /*                                            */
+                                /**********************************************/
+
+                                for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
+                                {
+
+                                    /******************************************/
+                                    /*                                        */
+                                    /* Initial model fit.                     */
+                                    /*                                        */
+                                    /******************************************/
+
+                                    status = auto_ts_fit(clrx, clry, b, i_start-1, i-1, 
+                                             MIN_NUM_C, fit_cft, &rmse[b], rec_v_dif); 
+                                    if (status != SUCCESS)  
+                                    {
+                                        RETURN_ERROR ("Calling auto_ts_fit during model initilization\n", 
+                                             FUNC_NAME, FAILURE);
+                                    }
+                                }
+
+                                v_dif_norm = 0.0;
+                                for(b = 0; b < NUM_LASSO_BANDS; b++)
+                                {
+                                    /******************************************/
+                                    /*                                        */
+                                    /* Calculate min. rmse.                   */
+                                    /*                                        */
+                                    /******************************************/
+
+                                    mini_rmse = max(adj_rmse[lasso_blist[b]], rmse[lasso_blist[b]]);
+
+                                    /******************************************/
+                                    /*                                        */
+                                    /* Compare the first observation.         */
+                                    /*                                        */
+                                    /******************************************/
+
+                                    v_start[b] = rec_v_dif[lasso_blist[b]][0] 
+                                            / mini_rmse;
+
+                                    /******************************************/
+                                    /*                                        */
+                                    /* Compare the last clear observation.    */
+                                    /*                                        */
+                                    /******************************************/
+
+                                    v_end[b] = rec_v_dif[lasso_blist[b]][i-i_start]
+                                                            / mini_rmse;
+
+                                    /******************************************/
+                                    /*                                        */
+                                    /* Anormalized slope values.              */
+                                    /*                                        */
+                                    /******************************************/
+
+                                    v_slope[b] = fit_cft[lasso_blist[b]][1] *
+                                                    (clrx[i-1]-clrx[i_start-1])/mini_rmse;
+
+                                    /******************************************/
+                                    /*                                        */
+                                    /* Difference in model intialization.     */
+                                    /*                                        */
+                                    /******************************************/
+
+                                    v_dif[b] = fabs(v_slope[b]) + fabs(v_start[b]) + fabs(v_end[b]); 
+                                    v_dif_norm += v_dif[b] * v_dif[b];               
+                                }
+    
+                                /**********************************************/
+                                /*                                            */
+                                /* Find stable start for each curve.          */
+                                /*                                            */
+                                /**********************************************/
+
+                                if (v_dif_norm > T_CG)
+                                {
+                                    /******************************************/
+                                    /*                                        */
+                                    /* Start from next clear observation.     */
+                                    /*                                        */
+                                    /******************************************/
+
+                                    i_start++;
+
+                                    /******************************************/
+                                    /*                                        */
+                                    /* Move forward to the i+1th clear        */
+                                    /* observation.                           */
+                                    /*                                        */
+                                    /******************************************/
+
+                                    i++;
+
+                                    /******************************************/
+                                    /*                                        */
+                                    /* Keep all data and move to the next obs.*/
+                                    /*                                        */
+                                    /******************************************/
+
+                                    continue;
+                                }
+                                else
+                                {
+
+                                    /******************************************/
+                                    /*                                        */
+                                    /* Model is ready.                        */
+                                    /*                                        */
+                                    /******************************************/
+
+                                    bl_train = 1;
+
+                                    /******************************************/
+                                    /*                                        */
+                                    /* Count difference of i for each         */
+                                    /* iteration.                             */
+                                    /*                                        */
+                                    /******************************************/
+
+                                    i_count = 0;
+
+                                    /******************************************/
+                                    /*                                        */
+                                    /* Find the previous break point.         */
+                                    /*                                        */
+                                    /******************************************/
+
+                                    if (num_fc == rec_fc)
+                                    {
+                                        i_break = 1; /* first curve */
+                                    }
+                                    else
+                                    {
+                                        /**************************************/
+                                        /*                                    */
+                                        /* After the first curve, compare     */
+                                        /* rmse to determine which curve to   */
+                                        /* determine t_break.                 */
+                                        /*                                    */
+                                        /**************************************/
+
+                                        for (k = 0; k < end; k++) 
+                                        {
+                                            if (clrx[k] >= rec_cg[num_fc-1].t_break)
+                                            {
+                                                i_break = k + 1;
+                                                break;
+                                            }
+                                        }
+                                    }
+
+                                    if (i_start > i_break)
+                                    {
+                                        /**************************************/
+                                        /*                                    */
+                                        /* Model fit at the beginning of the  */
+                                        /* time series.                       */
+                                        /*                                    */
+                                        /**************************************/
+
+                                        for(i_ini = i_start-2; i_ini >= i_break-1; i_ini--)
+                                        {
+                                            if ((i_start - i_break) < CONSE)
+                                            {
+                                                ini_conse = i_start - i_break;
+                                            }
+                                            else
+                                            {
+                                                ini_conse = CONSE;
+                                            }
+
+
+                                            /**********************************/
+                                            /*                                */
+                                            /* Allocate memory for            */ 
+                                            /* model_v_dif, v_diff, vec_magg  */ 
+                                            /* for the non-stdin branch here. */
+                                            /*                                */
+                                            /**********************************/
+
+                                            v_diff = (float **) allocate_2d_array(NUM_LASSO_BANDS,
+                                                        ini_conse, sizeof (float));
+                                            if (v_diff == NULL)
+                                            {
+                                                RETURN_ERROR ("Allocating v_diff memory", 
+                                                               FUNC_NAME, FAILURE);
+                                            }
+ 
+                                            vec_magg = (float *) malloc(ini_conse * sizeof (float));
+                                            if (vec_magg == NULL)
+                                            {
+                                                RETURN_ERROR ("Allocating vec_magg memory", 
+                                                              FUNC_NAME, FAILURE);
+                                            }
+
+                                            /**********************************/
+                                            /*                                */
+                                            /* Detect change.                 */
+                                            /* value of difference for CONSE  */
+                                            /* obsservations                  */
+                                            /* Record the magnitude of change */
+                                            /*                                */
+                                            /**********************************/
+
+                                            vec_magg_min = 9999.0;
+                                            for (i_conse = 0; i_conse < ini_conse; i_conse++)
+                                            {
+                                                v_dif_norm = 0.0;
+                                                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                                                {
+                                                    /**************************/
+                                                    /*                        */
+                                                    /* Absolute differences.  */
+                                                    /*                        */
+                                                    /**************************/
+
+                                                    auto_ts_predict(clrx, fit_cft, MIN_NUM_C, i_b, i_ini-i_conse,
+                                                                    i_ini-i_conse, &ts_pred_temp);
+                                                    v_dif_mag[i_b][i_conse] = (float)clry[i_b][i_ini-i_conse] - 
+                                                                       ts_pred_temp;
+
+                                                    /**************************/
+                                                    /*                        */
+                                                    /* Normalize to z-score.  */
+                                                    /*                        */
+                                                    /**************************/
+
+                                                    for (b = 0; b < NUM_LASSO_BANDS; b++)
+                                                    {
+                                                        if (i_b == lasso_blist[b])
+                                                        {
+                                                            /******************/
+                                                            /*                */
+                                                            /* Minimum rmse.  */ 
+                                                            /*                */
+                                                            /******************/
+
+                                                            mini_rmse = max(adj_rmse[i_b], rmse[i_b]);
+
+                                                            /******************/
+                                                            /*                */
+                                                            /* z-scores.      */
+                                                            /*                */
+                                                            /******************/
+
+                                                            v_diff[b][i_conse] = v_dif_mag[i_b][i_conse] 
+                                                                                          / mini_rmse;
+                                                            v_dif_norm += v_diff[b][i_conse] * v_diff[b][i_conse];
+                                                        }
+                                                    }
+                                                }
+                                                vec_magg[i_conse] = v_dif_norm; 
+
+                                                if (vec_magg_min > vec_magg[i_conse])
+                                                {
+                                                    vec_magg_min =  vec_magg[i_conse];
+                                                }
+                                            }
+
+                                            /**********************************/
+                                            /*                                */
+                                            /* Change detection.              */
+                                            /*                                */
+                                            /**********************************/
+
+                                            if (vec_magg_min > T_CG) /* change detected */
+                                            {
+                                                break;
+                                            }
+                                            else if (vec_magg[0] > T_MAX_CG) /* false change */
+                                            {
+                                                for (k = i_ini; k < end - 1; k++)
+                                                {
+                                                    clrx[k] = clrx[k+1];
+                                                    for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
+                                                    {
+                                                        clry[b][k] = clry[b][k+1];
+                                                    }
+                                                }
+                                                i--;
+                                                end--;
+
+                                                /******************************/
+                                                /*                            */
+                                                /* Update i_start if i_ini is */
+                                                /* not a confirmed break.     */
+                                                /*                            */
+                                                /******************************/
+
+                                                i_start = i_ini;
+                                            }
+
+                                            /**********************************/
+                                            /*                                */
+                                            /* Free the temporary memory.     */
+                                            /*                                */
+                                            /**********************************/
+
+                                            free(vec_magg);
+                                            status = free_2d_array ((void **) v_diff);
+                                            if (status != SUCCESS)
+                                            {
+                                                RETURN_ERROR ("Freeing memory: v_diff\n", 
+                                                              FUNC_NAME, FAILURE);
+                                            }
+                                        }
+                                    }
+
+                                    /******************************************/
+                                    /*                                        */
+                                    /* Enough to fit simple model and confirm */
+                                    /* a break.                               */
+                                    /*                                        */
+                                    /******************************************/
+
+                                    if ((num_fc == rec_fc) && ((i_start - i_break) >= CONSE))
+                                    {
+                                        /**************************************/
+                                        /*                                    */
+                                        /* Defining computed variables.       */
+                                        /*                                    */
+                                        /**************************************/
+
+                                        for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                                        {
+                                            status = auto_ts_fit(clrx, clry, i_b, i_break-1, i_start-2, 
+                                                     MIN_NUM_C, fit_cft, &rmse[i_b], temp_v_dif); 
+                                            if (status != SUCCESS)
+                                            {  
+                                                  RETURN_ERROR ("Calling auto_ts_fit with enough observations\n", 
+                                                             FUNC_NAME, FAILURE);
+                                            }
+                                        }
+
+                                        /**************************************/
+                                        /*                                    */
+                                        /* Record time of curve end,          */
+                                        /* postion of the pixels.             */
+                                        /*                                    */
+                                        /**************************************/
+
+                                        rec_cg[num_fc].t_end = clrx[i_start-2]; 
+                                        rec_cg[num_fc].pos = (row-1) * ncols + col_inx + 1; 
+
+                                        for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                                        {
+                                            for (k = 0; k < MIN_NUM_C; k++)
+                                            {
+                                                /******************************/
+                                                /*                            */
+                                                /* Record fitted coefficients.*/
+                                                /*                            */
+                                                /******************************/
+
+                                                rec_cg[num_fc].coefs[i_b][k] = fit_cft[i_b][k]; 
+                                             }
+
+                                            /**********************************/
+                                            /*                                */
+                                            /* Record rmse of the pixel.      */                         
+                                            /*                                */
+                                            /**********************************/
+
+                                            rec_cg[num_fc].rmse[i_b] = rmse[i_b]; 
+                                        }
+
+                                        /**************************************/
+                                        /*                                    */
+                                        /* Record break time, fit category,   */
+                                        /* change probability, time of curve  */
+                                        /* start, number of observations,     */
+                                        /* change magnitude.                  */
+                                        /*                                    */
+                                        /**************************************/
+
+                                        rec_cg[num_fc].t_break = clrx[i_start -1];
+                                        rec_cg[num_fc].category = 10 + MIN_NUM_C;
+                                        rec_cg[num_fc].change_prob = 1.0;
+                                        rec_cg[num_fc].t_start = clrx[0];
+                                        rec_cg[num_fc].num_obs = i_start - i_break;
+
+                                        for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                                        {
+                                            quick_sort_float(v_dif_mag[i_b], 0, ini_conse-1);
+                                            matlab_2d_float_median(v_dif_mag, i_b, ini_conse, 
+                                                                  &v_dif_mean);
+                                            rec_cg[num_fc].magnitude[i_b] = -v_dif_mean; 
+                                        }
+
+                                        /**************************************/
+                                        /*                                    */
+                                        /* Identified and move on for the     */
+                                        /* nex tfunctional curve.             */
+                                        /*                                    */
+                                        /**************************************/
+
+                                        num_fc++;  
+                                        if (num_fc >= MAX_NUM_FC)
+                                        {
+                                            /**********************************/
+                                            /*                                */
+                                            /* Reallocate memory for rec_cg.  */ 
+                                            /*                                */
+                                            /**********************************/
+
+                                            rec_cg = realloc(rec_cg, (num_fc + 1) * sizeof(Output_t));
+                                            if (rec_cg == NULL)
+                                            {
+                                                RETURN_ERROR("ERROR allocating rec_cg memory", 
+                                                             FUNC_NAME, FAILURE);
+                                            }
+                                        }           
+                                    }
+                                }
+                            }
+                        }
+                    } /* end of initializing model */
+ 
+                    /******************************************************/
+                    /*                                                    */
+                    /* Allocate memory for v_diff for the non-stdin branch*/ 
+                    /*                                                    */
+                    /******************************************************/
+
+                    v_diff = (float **) allocate_2d_array(NUM_LASSO_BANDS,
+                                      CONSE, sizeof (float));
+                    if (v_diff == NULL)
+                    {
+                        RETURN_ERROR ("Allocating v_diff memory", 
                                       FUNC_NAME, FAILURE);
-		    }
+                    }
 
-                    /**************************************************/
-                    /*                                                */
-                    /* Clear the IDs buffers.                         */
-                    /*                                                */
-                    /**************************************************/
+                    /******************************************************/
+                    /*                                                    */
+                    /* Continuous monitoring started!!!                   */
+                    /*                                                    */
+                    /******************************************************/
 
-                    for (k = 0; k < valid_num_scenes; k++)
-                        ids[k] = 0;
+                    if (bl_train == 1)
+                    {
+                        /**************************************************/
+                        /*                                                */
+                        /* Clears the IDs buffers.                        */
+                        /*                                                */
+                        /**************************************************/
 
-                    /**************************************************/
-                    /*                                                */
-                    /* IDs to be removed.                             */
-                    /*                                                */
-                    /**************************************************/
+                        for (k = 0; k < valid_num_scenes; k++)
+                        {
+                            ids[k] = 0;
+                        }
 
-                    for (k = i_start-1; k < i+CONSE; k++)
-		    {
+                        /**************************************************/
+                        /*                                                */
+                        /* All IDs.                                       */
+                        /*                                                */
+                        /**************************************************/
+
+                        ids_len = 0;
+                        for (k = i_start-1; k < i; k++)
+                        {
+                            ids[k-i_start+1] = k;
+                            ids_len++;
+                        }
+                        i_span = i - i_start +1;
+
+                        /**************************************************/
+                        /*                                                */
+                        /* Determine the time series model.               */
+                        /*                                                */
+                        /**************************************************/
+
+                        update_cft(i_span, N_TIMES, MIN_NUM_C, MID_NUM_C, MAX_NUM_C, 
+                                   num_c, &update_num_c);
+
+                        /******************************************************/
+                        /*                                                    */
+                        /* initial model fit when there are not many observations.*/
+                        /* if (i_count == 0 || ids_old_len < (N_TIMES * MAX_NUM_C))*/
+                        /*                                                    */
+                        /******************************************************/
+
+                        if (i_count == 0 || i_span <= (N_TIMES * MAX_NUM_C))
+                        {
+                            /**********************************************/
+                            /*                                            */
+                            /* update i_count at each iteration.          */
+                            /*                                            */
+                            /**********************************************/
+
+                            i_count = clrx[i-1] - clrx[i_start-1];
+
+                            for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                            {
+                                status = auto_ts_fit(clrx, clry, i_b, i_start-1, i-1, update_num_c, 
+                                                     fit_cft, &rmse[i_b], rec_v_dif); 
+                                if (status != SUCCESS) 
+                                { 
+                                    RETURN_ERROR ("Calling auto_ts_fit during continuous monitoring\n", 
+                                                  FUNC_NAME, FAILURE);
+                                }
+                            }
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Updating information for the first         */
+                            /* iteration.  Record time of curve start and */
+                            /* time of curve end.                         */
+                            /*                                            */
+                            /**********************************************/
+
+                            rec_cg[num_fc].t_start = clrx[i_start-1]; 
+                            rec_cg[num_fc].t_end = clrx[i-1]; 
+
+                            /**********************************************/
+                            /*                                            */
+                            /* No break at the moment.                    */
+                            /*                                            */
+                            /**********************************************/
+
+                            rec_cg[num_fc].t_break = 0; 
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Record postion of the pixel.               */
+                            /*                                            */
+                            /**********************************************/
+
+                            rec_cg[num_fc].pos = (row-1) * ncols + col_inx + 1; // offsets
+
+                            for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                            {
+                                for (k = 0; k < MAX_NUM_C; k++)
+                                {
+                                    /**************************************/
+                                    /*                                    */
+                                    /* Record fitted coefficients.        */
+                                    /*                                    */
+                                    /**************************************/
+
+                                    rec_cg[num_fc].coefs[i_b][k] = fit_cft[i_b][k]; 
+                                }
+                                /******************************************/
+                                /*                                        */
+                                /* Record rmse of the pixel.              */
+                                /*                                        */
+                                /******************************************/
+
+                                rec_cg[num_fc].rmse[i_b] = rmse[i_b]; 
+                            }
+                            /**********************************************/
+                            /*                                            */
+                            /* Record change probability, number of       */
+                            /* observations, fit category.                */
+                            /*                                            */
+                            /**********************************************/
+
+                            rec_cg[num_fc].change_prob = 0.0; 
+                            rec_cg[num_fc].num_obs = i-i_start+1; 
+                            rec_cg[num_fc].category = 0 + update_num_c; 
+
+                            for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                            {
+                                /******************************************/
+                                /*                                        */
+                                /* Record change magnitude.               */
+                                /*                                        */
+                                /******************************************/
+                                rec_cg[num_fc].magnitude[i_b] = 0.0; 
+                            }
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Detect change, value of difference for     */
+                            /* CONSE observations.                        */
+                            /*                                            */
+                            /**********************************************/
+
+                            for (i_conse = 0; i_conse < CONSE; i_conse++)
+                            {
+                                v_dif_norm = 0.0;
+                                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                                {
+                                    /**************************************/
+                                    /*                                    */
+                                    /* Absolute differences.              */
+                                    /*                                    */
+                                    /**************************************/
+
+                                    auto_ts_predict(clrx, fit_cft, update_num_c, i_b, i+i_conse, i+i_conse, 
+                                                    &ts_pred_temp);
+                                    v_dif_mag[i_b][i_conse] = (float)clry[i_b][i+i_conse] - ts_pred_temp; 
+
+                                    /**************************************/
+                                    /*                                    */
+                                    /* Normalize to z-score.              */
+                                    /*                                    */
+                                    /**************************************/
+
+                                    for (b = 0; b < NUM_LASSO_BANDS; b++)
+                                    {
+                                        if (i_b == lasso_blist[b])
+                                        {
+                                            /******************************/
+                                            /*                            */
+                                            /* Minimum rmse, z-scores.    */ 
+                                            /*                            */
+                                            /******************************/
+
+                                            mini_rmse = max(adj_rmse[i_b], rmse[i_b]);
+                                            v_diff[b][i_conse] = v_dif_mag[i_b][i_conse] / mini_rmse;
+                                            v_dif_norm += v_diff[b][i_conse] * v_diff[b][i_conse];
+                                        }
+                                    }
+                                }
+                                vec_mag[i_conse] = v_dif_norm;
+                            }
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Clears the IDs_old buffers.                */
+                            /*                                            */
+                            /**********************************************/
+
+                            for (k = 0; k < ids_len; k++)
+                            {
+                                ids_old[k] = 0;
+                            }
+
+                            /**********************************************/
+                            /*                                            */
+                            /* IDs that have not been updated.            */
+                            /*                                            */
+                            /**********************************************/
+
+                            for (k = 0; k < ids_len; k++)
+                            {
+                                ids_old[k] = ids[k];
+                            }
+                            ids_old_len = ids_len;
+
+                        }
+                        else
+                        {
+                            if ((float)(clrx[i-1] - clrx[i_start-1]) >= (1.33*(float)i_count))
+                            {
+                                /******************************************/
+                                /*                                        */
+                                /* Update i_count at each iteration year. */
+                                /*                                        */
+                                /******************************************/
+
+                                i_count = clrx[i-1] - clrx[i_start-1];
+
+                                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                                {
+                                    status = auto_ts_fit(clrx, clry, i_b, i_start-1, i-1, update_num_c, 
+                                                         fit_cft, &rmse[i_b], rec_v_dif); 
+                                    if (status != SUCCESS)  
+                                    {
+                                        RETURN_ERROR ("Calling auto_ts_fit for change detection with "
+                                             "enough observations\n", FUNC_NAME, FAILURE);
+                                    }
+                                }
+
+                                /******************************************/
+                                /*                                        */
+                                /* Record fitted coefficients.            */
+                                /*                                        */
+                                /******************************************/
+                                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                                {
+                                    for (k = 0; k < MAX_NUM_C; k++)
+                                    {
+                                        /**********************************/
+                                        /*                                */
+                                        /* Record fitted coefficients.    */
+                                        /*                                */
+                                        /**********************************/
+
+                                        rec_cg[num_fc].coefs[i_b][k] = fit_cft[i_b][k];
+                                    } 
+                                    /**************************************/
+                                    /*                                    */
+                                    /* Record rmse of the pixel.          */
+                                    /*                                    */
+                                    /**************************************/
+
+                                    rec_cg[num_fc].rmse[i_b] = rmse[i_b]; 
+                                }
+                                /******************************************/
+                                /*                                        */
+                                /* Record number of observations, fit     */
+                                /* category.                              */
+                                /*                                        */
+                                /******************************************/
+
+                                rec_cg[num_fc].num_obs = i-i_start+1; 
+                                rec_cg[num_fc].category = 0 + update_num_c; 
+
+                                /******************************************/
+                                /*                                        */
+                                /* Clears the IDs_Old buffers.            */
+                                /*                                        */
+                                /******************************************/
+
+                                for (k = 0; k < ids_len; k++)
+                                {
+                                    ids_old[k] = 0;
+                                }
+
+                                /******************************************/
+                                /*                                        */
+                                /* IDs that have not been updated.        */
+                                /*                                        */
+                                /******************************************/
+
+                                for (k = 0; k < ids_len; k++)
+                                {
+                                    ids_old[k] = ids[k];
+                                }
+                                ids_old_len = ids_len;
+
+                            }
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Record time of curve end.                  */
+                            /*                                            */
+                            /**********************************************/
+
+                            rec_cg[num_fc].t_end = clrx[i-1];
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Use fixed number for RMSE computing.       */
+                            /*                                            */
+                            /**********************************************/
+
+                            n_rmse = N_TIMES * rec_cg[num_fc].category;
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Better days counting for RMSE calculating  */
+                            /* relative days distance.                    */
+                            /*                                            */
+                            /**********************************************/
+
+                            if (ids_old_len == 0)
+                            {
+                                RETURN_ERROR ("No data points for RMSE calculating", 
+                                             FUNC_NAME, FAILURE);
+                            }
+
+                            d_yr = malloc(ids_old_len * sizeof(float));
+                            if (d_yr == NULL)
+                            {
+                                RETURN_ERROR ("Allocating d_yr memory", 
+                                             FUNC_NAME, FAILURE);
+                            }
+ 
+                            for(m = 0; m < ids_old_len; m++)
+                            {
+                                d_rt = clrx[ids_old[m]] - clrx[i+CONSE-1]; 
+                                d_yr[m] = fabs(round((float)d_rt / NUM_YEARS) * NUM_YEARS - (float)d_rt);
+                            }
+
+                            for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
+                            {
+                                for (m = 0; m < ids_old_len; m++)
+                                    rec_v_dif_copy[b][m] = rec_v_dif[b][m];
+                            }
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Sort the rec_v_dif based on d_yr.          */
+                            /*                                            */
+                            /**********************************************/
+
+                            quick_sort_2d_float(d_yr, rec_v_dif_copy, 0, ids_old_len-1);
+                            for(b = 0; b < NUM_LASSO_BANDS; b++)
+                                tmpcg_rmse[b] = 0.0;
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Temporarily changing RMSE.                 */
+                            /*                                            */
+                            /**********************************************/
+
+                            for (b = 0; b < NUM_LASSO_BANDS; b++)
+                            {
+                                matlab_2d_array_norm(rec_v_dif_copy, lasso_blist[b], n_rmse,
+                                                 &tmpcg_rmse[b]);
+                                tmpcg_rmse[b] /= sqrt(n_rmse - rec_cg[num_fc].category);
+                            }
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Free allocated memories.                   */
+                            /*                                            */
+                            /**********************************************/
+                            free(d_yr);
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Move the ith col to i-1th col.             */
+                            /*                                            */
+                            /**********************************************/
+
+                            for (m = 0; m < CONSE-1; m++)
+                            {
+                                vec_mag[m] = vec_mag[m+1];
+                                for (b = 0; b < NUM_LASSO_BANDS; b++)
+                                    v_diff[b][m] = v_diff[b][m+1];
+                                for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
+                                    v_dif_mag[b][m] = v_dif_mag[b][m+1];
+                            }
+
+                            for (b = 0; b < NUM_LASSO_BANDS; b++)
+                                v_diff[b][CONSE-1] = 0.0;
+                            for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
+                                v_dif_mag[b][CONSE-1] = 0.0;
+                            vec_mag[CONSE-1] = 0.0;
+
+                            for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                            {
+                                /******************************************/
+                                /*                                        */
+                                /* Absolute difference for all bands.     */
+                                /*                                        */
+                                /******************************************/
+
+                                auto_ts_predict(clrx, fit_cft, update_num_c, i_b, i+CONSE-1, 
+                                                i+CONSE-1, &ts_pred_temp);
+                                v_dif_mag[i_b][CONSE-1] = clry[i_b][i+CONSE-1] - ts_pred_temp;
+
+                                /******************************************/
+                                /*                                        */
+                                /* Normalized to z-scores.                */
+                                /*                                        */
+                                /******************************************/
+                                for (b = 0; b < NUM_LASSO_BANDS; b++)
+                                {
+                                    if (i_b == lasso_blist[b])
+                                    {
+                                        /**********************************/
+                                        /*                                */
+                                        /* Minimum rmse.                  */
+                                        /*                                */
+                                        /**********************************/
+                                        mini_rmse = max(adj_rmse[i_b], tmpcg_rmse[b]);
+
+                                        /**********************************/
+                                        /*                                */
+                                        /* Z-score.                       */
+                                        /*                                */
+                                        /**********************************/
+
+                                        v_diff[b][CONSE-1] = v_dif_mag[i_b][CONSE-1] / mini_rmse;
+                                        vec_mag[CONSE-1] += v_diff[b][CONSE-1] * v_diff[b][CONSE-1]; 
+                                    }         
+                                }
+                            }
+                        }
+
+                        break_mag = 9999.0;
+                        for (m = 0; m < CONSE; m++)
+                        {
+                            if (break_mag > vec_mag[m])
+                            {
+                                break_mag = vec_mag[m];
+                            }
+                        }
+
+                        if (break_mag > T_CG)
+                        {
+
+                            if (debug)
+                            {
+                                printf("Change Magnitude = %.2f\n", break_mag - T_CG);
+                            }
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Record break time.                        */
+                            /*                                            */
+                            /**********************************************/
+
+                            rec_cg[num_fc].t_break = clrx[i];
+                            rec_cg[num_fc].change_prob = 1.0;
+
+                            for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                            {
+                                quick_sort_float(v_dif_mag[i_b], 0, CONSE-1);
+                                matlab_2d_float_median(v_dif_mag, i_b, CONSE,
+                                                       &rec_cg[num_fc].magnitude[i_b]);
+                            }
+                            /**********************************************/
+                            /*                                            */
+                            /* Identified and move on for the next        */
+                            /* functional curve.                          */
+                            /*                                            */
+                            /**********************************************/
+
+                            num_fc++;
+
+                            if (num_fc >= MAX_NUM_FC)
+                            {
+                                /******************************************/
+                                /*                                        */
+                                /* Reallocate memory for rec_cg.          */ 
+                                /*                                        */
+                                /******************************************/
+
+                                rec_cg = realloc(rec_cg, (num_fc + 1) * sizeof(Output_t));
+                                if (rec_cg == NULL)
+                                {
+                                    RETURN_ERROR("ERROR allocating rec_cg memory", 
+                                                         FUNC_NAME, FAILURE);
+                                }
+                            }
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Start from i+1 for the next functional     */
+                            /* curve.                                     */
+                            /*                                            */
+                            /**********************************************/
+
+                            i_start = i + 1;
+
+                            /**********************************************/
+                            /*                                            */
+                            /* Start training again.                      */
+                            /*                                            */
+                            /**********************************************/
+
+                            bl_train = 0;
+                        }
+                        else if (vec_mag[0] > T_MAX_CG)
+                        {
+                            /**********************************************/
+                            /*                                            */
+                            /* Remove noise.                              */
+                            /*                                            */
+                            /**********************************************/
+
+                            for (m = i; m < end -1; m++)
+                            {
+                                clrx[m] = clrx[m+1];
+                                for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
+                                    clry[b][m] = clry[b][m+1];
+                            }
+                            end--; /* check if this is needed */
+
+                            i--;   /* stay & check again after noise removal */
+                        }
+                        status = free_2d_array ((void **) v_diff);
+                        if (status != SUCCESS)
+                        {
+                            RETURN_ERROR ("Freeing memory: v_diff\n", 
+                                          FUNC_NAME, FAILURE);
+                        }
+                    } /* end of continuous monitoring */ 
+                }  /* end of checking basic requrirements */ 
+
+                /**********************************************************/
+                /*                                                        */
+                /* Move forward to the i+1th clear observation.           */
+                /*                                                        */
+                /**********************************************************/
+
+                i++;
+
+            } /* end of "while (i <= end - CONSE) */
+
+            /**************************************************************/
+            /*                                                            */
+            /* Two ways for processing the end of the time series.        */ 
+            /*                                                            */
+            /**************************************************************/
+
+            if (bl_train == 1)
+            {
+
+                /**********************************************************/
+                /*                                                        */
+                /* If no break, find at the end of the time series,       */
+                /* define probability of change based on CONSE.           */
+                /*                                                        */
+                /**********************************************************/
+
+                for (i_conse = CONSE - 1; i_conse >= 0; i_conse--)
+                {
+                    if (vec_mag[i_conse] <= T_CG)
+                    {
+                        /**************************************************/
+                        /*                                                */
+                        /* The last stable ID.                            */
+                        /*                                                */
+                        /**************************************************/
+
+                        id_last = i_conse + 1;
+                        break;
+                    }
+                } 
+
+                /**********************************************************/
+                /*                                                        */
+                /* Update change probability, end time of the curve.      */
+                /*                                                        */
+                /**********************************************************/
+
+                rec_cg[num_fc].change_prob = (CONSE - id_last) / CONSE; 
+                rec_cg[num_fc].t_end = clrx[end - CONSE + id_last];
+
+                /**********************************************************/
+                /*                                                        */
+                /* Mean value fit for the rest of the pixels < CONSE & > 1*/
+                /*                                                        */
+                /**********************************************************/
+
+                if (CONSE > id_last)
+                {
+                    /******************************************************/
+                    /*                                                    */
+                    /* Update time of the probable change.                */
+                    /*                                                    */
+                    /******************************************************/
+
+                    rec_cg[num_fc].t_break = clrx[end-CONSE+id_last+1];
+
+                    /******************************************************/
+                    /*                                                    */
+                    /* Update magnitude of change.                        */
+                    /*                                                    */
+                    /******************************************************/
+
+                    for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                    {
+                        quick_sort_float(v_dif_mag[i_b], id_last, CONSE-2);
+                        matlab_float_2d_partial_median(v_dif_mag, i_b, id_last, CONSE-1,
+                                                       &rec_cg[num_fc].magnitude[i_b]);
+                    }
+                }
+            }
+
+            else if (bl_train == 0)
+
+            {
+                /**********************************************************/
+                /*                                                        */
+                /* If break found close to the end of the time series,    */ 
+                /* use [CONSE,MIN_NUM_C*N_TIMES+CONSE) to fit curve.      */
+                /*                                                        */
+                /* Update i_start.                                        */
+                /*                                                        */
+                /**********************************************************/
+                if (num_fc == rec_fc)
+                {
+                    /******************************************************/
+                    /*                                                    */
+                    /* First curve.                                       */
+                    /*                                                    */
+                    /******************************************************/
+
+                    i_start = 1;
+                }
+                else
+                {
+                    for (k = 0; k < valid_num_scenes; k++) 
+                    {
+                        if (clrx[k] >= rec_cg[num_fc-1].t_break)
+                        {
+                            i_start = k + 1;
+			    break;
+                        }
+                    }
+                }
+
+                for (m = 0; m < valid_num_scenes; m++)
+                {
+                    bl_ids[m] = 0;
+                }
+
+                if ((end - i_start + 1) > CONSE)
+                {
+                    /******************************************************/
+                    /*                                                    */
+                    /* Multitemporal cloud mask.                          */
+                    /*                                                    */
+                    /******************************************************/
+
+                    status = auto_mask(clrx, clry, i_start-1, end-1,
+                                       (float)(clrx[end-1]-clrx[i_start-1]) / NUM_YEARS, 
+                                       adj_rmse[1], adj_rmse[4], T_CONST, bl_ids);
+                    if (status != SUCCESS)
+                        RETURN_ERROR("ERROR calling auto_mask at the end of time series", 
+                                      FUNC_NAME, FAILURE);
+
+                    /******************************************************/
+                    /*                                                    */
+                    /* Clears the IDs buffers.                            */
+                    /*                                                    */
+                    /******************************************************/
+
+                    for (m = 0; m < valid_num_scenes-1; m++)
+                    {
+                        ids[m] = 0;
+                    }
+
+                    /******************************************************/
+                    /*                                                    */
+                    /* IDs to be removed.                                 */
+                    /*                                                    */
+                    /******************************************************/
+
+                    for (k = i_start-1; k < end; k++)
+                    {
                         ids[k-i_start+1] = k;
-		    }
+                    }
                     m= 0;
                     i_span = 0;
-                    for (k = 0; k < i-i_start+1; k++)
+                    for (k = 0; k < end-i_start+1; k++)
                     {
                         if (bl_ids[k] == 1) 
                         {
@@ -1518,1408 +2910,105 @@ int main (int argc, char *argv[])
                         else
                             i_span++;  /* update i_span after noise removal */
                     }
-
                     rm_ids_len = m;
 
-                    /**************************************************/
-                    /*                                                */
-                    /* Check if there are enough observation.         */
-                    /*                                                */
-                    /**************************************************/
-
-                    if (i_span < (N_TIMES * MIN_NUM_C))
-                    {
-                        /**********************************************/
-                        /*                                            */
-                        /* Move forward to the i+1th clear observation*/
-                        /*                                            */
-                        /**********************************************/
-
-                        i++;
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Not enough clear observations.             */
-                        /*                                            */
-                        /**********************************************/
-
-                        continue;
-                    }
-
-		    if (end == 0)
-                        RETURN_ERROR("No available data point", FUNC_NAME, FAILURE);
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Allocate memory for cpx, cpy.                  */
-                    /*                                                */
-                    /**************************************************/
-
-                    cpx = malloc(end * sizeof(int));
-                    if (cpx == NULL)
-                        RETURN_ERROR("ERROR allocating cpx memory", FUNC_NAME, FAILURE);
-
-                    cpy = (float **) allocate_2d_array (TOTAL_IMAGE_BANDS, end,
-                                     sizeof (float));
-                    if (cpy == NULL)
-                    {
-                        RETURN_ERROR ("Allocating cpy memory", FUNC_NAME, FAILURE);
-                    }
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Remove noise pixels between i_start & i.       */
-                    /*                                                */
-                    /**************************************************/
+                    /******************************************************/
+                    /*                                                    */
+                    /* Remove noise pixels between i_start & i.           */
+                    /*                                                    */
+                    /******************************************************/
 
                     m = 0;
-                    for (k = 0, k_new=0; k < end; k++)
+                    for (k = 0, k_new=0; k < end-i_start+1; k++)
                     {
                         if (m < rm_ids_len && k == rm_ids[m])
                         {
                             m++;
-			    continue;
+                            end--;
+                            continue;
                         }
-                        cpx[k_new] = clrx[k];
-                        for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
-			{
-                            cpy[b][k_new] = clry[b][k];
-			}
+                        clrx[k_new] = clrx[k];
+                        for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                             clry[i_b][k_new] = clry[i_b][k];
                         k_new++;
                     }
-                    end = k_new;
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Record i before noise removal.                 */ 
-                    /* This is very important, ie model is not yet    */
-                    /* initialized.   The multitemporal masking shall */
-                    /* be done again instead of removing outliers  In */
-                    /* every masking.                                 */
-                    /*                                                */
-                    /**************************************************/
-
-                    i_rec = i;
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Update i afer noise removal.                   */
-                    /*     (i_start stays the same).                  */
-                    /*                                                */
-                    /**************************************************/
-
-                    i = i_start + i_span - 1;
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Update span of time (num of years).            */
-                    /*                                                */
-                    /**************************************************/
-
-                    time_span=(cpx[i-1] - cpx[i_start-1]) / NUM_YEARS;
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Check if there is enough time.                 */
-                    /*                                                */
-                    /**************************************************/
-
-                    if (time_span < MIN_YEARS)
-                    {
-                        i = i_rec;   /* keep the original i */
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Move forward to the i+1th clear observation*/
-                        /*                                            */
-                        /**********************************************/
-
-                        i++;        
-                        free(cpx);
-                        status = free_2d_array ((void **) cpy);
-                        if (status != SUCCESS)
-			{
-                              RETURN_ERROR ("Freeing memory: cpy\n", 
-                                    FUNC_NAME, FAILURE);
-			}
-                        continue;    /* not enough time */
-                    }
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Remove noise in original arrays.               */
-                    /*                                                */
-                    /**************************************************/
-
-                    for (k = 0; k < end; k++)
-                    {
-                        clrx[k] = cpx[k];
-                        for (m = 0; m < TOTAL_IMAGE_BANDS; m++)
-			{
-                            clry[m][k] = cpy[m][k];
-			}
-                    }
-
-                    free(cpx);
-                    status = free_2d_array ((void **) cpy);
-                    if (status != SUCCESS)
-		    {
-                        RETURN_ERROR ("Freeing memory: cpy\n", 
-                             FUNC_NAME, FAILURE);
-		    }
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Step 2) model fitting: initialize model testing*/
-                    /*         variables defining computed variables. */
-                    /*                                                */
-                    /**************************************************/
-
-                    for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
-                    {
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Initial model fit.                         */
-                        /*                                            */
-                        /**********************************************/
-
-                        status = auto_ts_fit(clrx, clry, b, i_start-1, i-1, 
-                                 MIN_NUM_C, fit_cft, &rmse[b], rec_v_dif); 
-                        if (status != SUCCESS)  
-			{
-                            RETURN_ERROR ("Calling auto_ts_fit during model initilization\n", 
-                                 FUNC_NAME, FAILURE);
-			}
-                    }
-
-                    v_dif_norm = 0.0;
-                    for(b = 0; b < NUM_LASSO_BANDS; b++)
-                    {
-                        /**********************************************/
-                        /*                                            */
-                        /* Calculate min. rmse.                       */
-                        /*                                            */
-                        /**********************************************/
-
-                        mini_rmse = max(adj_rmse[lasso_blist[b]], rmse[lasso_blist[b]]);
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Compare the first observation.             */
-                        /*                                            */
-                        /**********************************************/
-
-                        v_start[b] = rec_v_dif[lasso_blist[b]][0] 
-                                / mini_rmse;
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Compare the last clear observation.        */
-                        /*                                            */
-                        /**********************************************/
-
-                        v_end[b] = rec_v_dif[lasso_blist[b]][i-i_start]
-                                                / mini_rmse;
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Anormalized slope values.                  */
-                        /*                                            */
-                        /**********************************************/
-                        v_slope[b] = fit_cft[lasso_blist[b]][1] *
-                                        (clrx[i-1]-clrx[i_start-1])/mini_rmse;
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Difference in model intialization.         */
-                        /*                                            */
-                        /**********************************************/
-
-                        v_dif[b] = fabs(v_slope[b]) + fabs(v_start[b]) + fabs(v_end[b]); 
-                        v_dif_norm += v_dif[b] * v_dif[b];               
-                    }
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Find stable start for each curve.              */
-                    /*                                                */
-                    /**************************************************/
-                    if (v_dif_norm > T_CG)
-                    {
-                        /**********************************************/
-                        /*                                            */
-                        /* Start from next clear observation.         */
-                        /*                                            */
-                        /**********************************************/
-
-                        i_start++;
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Move forward to the i+1th clear observation*/
-                        /*                                            */
-                        /**********************************************/
-
-                        i++;
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Keep all data and move to the next obs.    */
-                        /*                                            */
-                        /**********************************************/
-
-                        continue;
-                    }
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Model is ready.                                */
-                    /*                                                */
-                    /**************************************************/
-
-                    bl_train = 1;
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Count difference of i for each iteration.      */
-                    /*                                                */
-                    /**************************************************/
-
-                    i_count = 0;
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Find the previous break point.                 */
-                    /*                                                */
-                    /**************************************************/
-
-                    if (num_fc == rec_fc)
-		    {
-                        i_break = 1; /* first curve */
-		    }
-                    else
-                    {
-                        /**********************************************/
-                        /*                                            */
-                        /* After the first curve, compare rmse to     */
-                        /* determine which curve to determine t_break.*/
-                        /*                                            */
-                        /**********************************************/
-
-                        for (k = 0; k < end; k++) 
-                        {
-                            if (clrx[k] >= rec_cg[num_fc-1].t_break)
-                            {
-                                i_break = k + 1;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (i_start > i_break)
-                    {
-                        /**********************************************/
-                        /*                                            */
-                        /* Model fit at the beginning of the time     */
-                        /* series.                                    */
-                        /*                                            */
-                        /**********************************************/
-
-                        for(i_ini = i_start-2; i_ini >= i_break-1; i_ini--)
-                        {
-                            if ((i_start - i_break) < CONSE)
-			    {
-                                ini_conse = i_start - i_break;
-			    }
-                            else
-			    {
-                                ini_conse = CONSE;
-			    }
-
-			    if (ini_conse == 0)
-                            {
-                                RETURN_ERROR ("No data point for model fit at "
-                                      "the begining", FUNC_NAME, FAILURE);
-                            }
-
-                            /******************************************/
-                            /*                                        */
-                            /* Allocate memory for model_v_dif,       */ 
-                            /* v_diff, vec_magg for the non-stdin     */ 
-                            /* branch here.                           */
-                            /*                                        */
-                            /******************************************/
-
-                            v_diff = (float **) allocate_2d_array(NUM_LASSO_BANDS,
-                                        ini_conse, sizeof (float));
-                            if (v_diff == NULL)
-                            {
-                                RETURN_ERROR ("Allocating v_diff memory", 
-                                               FUNC_NAME, FAILURE);
-                            }
- 
-                            vec_magg = (float *) malloc(ini_conse * sizeof (float));
-                            if (vec_magg == NULL)
-                            {
-                                RETURN_ERROR ("Allocating vec_magg memory", 
-                                              FUNC_NAME, FAILURE);
-                            }
-
-                            /******************************************/
-                            /*                                        */
-                            /* Detect change.                         */
-                            /* value of difference for CONSE          */
-                            /* obsservations                          */
-                            /* Record the magnitude of change.        */
-                            /*                                        */
-                            /******************************************/
-
-                            vec_magg_min = 9999.0;
-                            for (i_conse = 0; i_conse < ini_conse; i_conse++)
-                            {
-                                v_dif_norm = 0.0;
-                                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                                {
-                                    /**********************************/
-                                    /*                                */
-                                    /* Absolute differences.          */
-                                    /*                                */
-                                    /**********************************/
-
-        			    auto_ts_predict(clrx, fit_cft, MIN_NUM_C, i_b, i_ini-i_conse,
-                                                    i_ini-i_conse, &ts_pred_temp);
-                                    v_dif_mag[i_b][i_conse] = (float)clry[i_b][i_ini-i_conse] - 
-                                                       ts_pred_temp;
-
-                                    /**********************************/
-                                    /*                                */
-                                    /* Normalize to z-score.          */
-                                    /*                                */
-                                    /**********************************/
-
-                                    for (b = 0; b < NUM_LASSO_BANDS; b++)
-                                    {
-                                        if (i_b == lasso_blist[b])
-                                        {
-                                            /**************************/
-                                            /*                        */
-                                            /* Minimum rmse.          */ 
-                                            /*                        */
-                                            /**************************/
-
-                                            mini_rmse = max(adj_rmse[i_b], rmse[i_b]);
-
-                                            /**************************/
-                                            /*                        */
-                                            /* z-scores.              */
-                                            /*                        */
-                                            /**************************/
-
-                                            v_diff[b][i_conse] = v_dif_mag[i_b][i_conse] 
-                                                                          / mini_rmse;
-                                            v_dif_norm += v_diff[b][i_conse] * v_diff[b][i_conse];
-                                        }
-                                    }
-                                }
-                                vec_magg[i_conse] = v_dif_norm; 
-
-                                if (vec_magg_min > vec_magg[i_conse])
-				{
-                                    vec_magg_min =  vec_magg[i_conse];
-				}
-                            }
-
-                            /******************************************/
-                            /*                                        */
-                            /* Change detection.                      */
-                            /*                                        */
-                            /******************************************/
-
-                            if (vec_magg_min > T_CG) /* change detected */
-			    {
-                                break;
-			    }
-                            else if (vec_magg[0] > T_MAX_CG) /* false change */
-                            {
-                                for (k = i_ini; k < end - 1; k++)
-                                {
-                                    clrx[k] = clrx[k+1];
-                                    for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
-				    {
-                                        clry[b][k] = clry[b][k+1];
-				    }
-                                }
-                                i--;
-                                end--;
-
-                                /**************************************/
-                                /*                                    */
-                                /* Update i_start if i_ini is not a   */
-                                /* confirmed break.                   */
-                                /*                                    */
-                                /**************************************/
-
-                                i_start = i_ini;
-			    }
-
-                            /******************************************/
-                            /*                                        */
-                            /* Free the temporary memory.             */
-                            /*                                        */
-                            /******************************************/
-
-                            free(vec_magg);
-                            status = free_2d_array ((void **) v_diff);
-                            if (status != SUCCESS)
-			    {
-                                RETURN_ERROR ("Freeing memory: v_diff\n", 
-                                              FUNC_NAME, FAILURE);
-			    }
-                        }
-                    }
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Enough to fit simple model and confirm a break.*/
-                    /*                                                */
-                    /**************************************************/
-
-                    if ((num_fc == rec_fc) && ((i_start - i_break) >= CONSE))
-		    {
-                        /**********************************************/
-                        /*                                            */
-                        /* Defining computed variables.               */
-                        /*                                            */
-                        /**********************************************/
-
-                        for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                        {
-                            status = auto_ts_fit(clrx, clry, i_b, i_break-1, i_start-2, 
-                                     MIN_NUM_C, fit_cft, &rmse[i_b], temp_v_dif); 
-                            if (status != SUCCESS)
-         		    {  
-                                  RETURN_ERROR ("Calling auto_ts_fit with enough observations\n", 
-                                             FUNC_NAME, FAILURE);
-	      	            }
-                        }
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Record time of curve end,                  */
-                        /* postion of the pixels.                     */
-                        /*                                            */
-                        /**********************************************/
-
-                        rec_cg[num_fc].t_end = clrx[i_start-2]; 
-                        rec_cg[num_fc].pos.row = row; 
-                        rec_cg[num_fc].pos.col = col; 
-
-                        for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                        {
-                            for (k = 0; k < MIN_NUM_C; k++)
-			    {
-                                /**************************************/
-                                /*                                    */
-                                /* Record fitted coefficients.        */
-                                /*                                    */
-                                /**************************************/
-
-                                rec_cg[num_fc].coefs[i_b][k] = fit_cft[i_b][k]; 
-	        	    }
-
-                            /******************************************/
-                            /*                                        */
-                            /* Record rmse of the pixel.              */                         
-                            /*                                        */
-                            /******************************************/
-
-                            rec_cg[num_fc].rmse[i_b] = rmse[i_b]; 
-                        }
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Record break time, fit category, change    */
-                        /* probability, time of curve start, number   */
-                        /* of observations, change magnitude.         */
-                        /*                                            */
-                        /**********************************************/
-
-			rec_cg[num_fc].t_break = clrx[i_start -1];
-			rec_cg[num_fc].category = 10 + MIN_NUM_C;
-			rec_cg[num_fc].change_prob = 1.0;
-			rec_cg[num_fc].t_start = clrx[0];
-			rec_cg[num_fc].num_obs = i_start - i_break;
-
-                        for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                        {
-                            quick_sort_float(v_dif_mag[i_b], 0, ini_conse-1);
-                            matlab_2d_float_median(v_dif_mag, i_b, ini_conse, 
-                                                  &v_dif_mean);
-                            rec_cg[num_fc].magnitude[i_b] = -v_dif_mean; 
-                        }
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Identified and move on for the next        */
-                        /* functional curve.                          */
-                        /*                                            */
-                        /**********************************************/
-
-                        num_fc++;  
-                        if (num_fc >= 10)
-		        {
-                            /******************************************/
-                            /*                                        */
-                            /* Reallocate memory for rec_cg.          */ 
-                            /*                                        */
-                            /******************************************/
-
-		            rec_cg = realloc(rec_cg, (num_fc + 1) * sizeof(Output_t));
-                            if (rec_cg == NULL)
-			    {
-                                RETURN_ERROR("ERROR allocating rec_cg memory", 
-                                             FUNC_NAME, FAILURE);
-			    }
-                        }           
-		    }
-		} /* end of initializing model */
- 
-                /******************************************************/
-                /*                                                    */
-                /* Allocate memory for v_diff for the non-stdin branch*/ 
-                /*                                                    */
-                /******************************************************/
-
-                v_diff = (float **) allocate_2d_array(NUM_LASSO_BANDS,
-                                  CONSE, sizeof (float));
-                if (v_diff == NULL)
-                {
-                    RETURN_ERROR ("Allocating v_diff memory", 
-                                  FUNC_NAME, FAILURE);
                 }
 
-                /******************************************************/
-                /*                                                    */
-                /* Continuous monitoring started!!!                   */
-                /*                                                    */
-                /******************************************************/
-
-                if (bl_train == 1)
+                if ((end - i_start + 1) >= CONSE)
                 {
-                    /**************************************************/
-                    /*                                                */
-                    /* Clears the IDs buffers.                        */
-                    /*                                                */
-                    /**************************************************/
-
-                    for (k = 0; k < valid_num_scenes; k++)
-		    {
-                        ids[k] = 0;
-		    }
-
-                    /**************************************************/
-                    /*                                                */
-                    /* All IDs.                                       */
-                    /*                                                */
-                    /**************************************************/
-
-                    ids_len = 0;
-                    for (k = i_start-1; k < i; k++)
-                    {
-                        ids[k-i_start+1] = k;
-                        ids_len++;
-                    }
-                    i_span = i - i_start +1;
-
-                    /**************************************************/
-                    /*                                                */
-                    /* Determine the time series model.               */
-                    /*                                                */
-                    /**************************************************/
-
-                    update_cft(i_span, N_TIMES, MIN_NUM_C, MID_NUM_C, MAX_NUM_C, 
-                              num_c, &update_num_c);
-
-                    /************************************************************/
-                    /*                                                          */
-                    /* initial model fit when there are not many observations.  */
-                    /* if (i_count == 0 || ids_old_len < (N_TIMES * MAX_NUM_C)) */
-                    /*                                                          */
-                    /************************************************************/
-
-                    if (i_count == 0 || i_span <= (N_TIMES * MAX_NUM_C))
-                    {
-                        /**********************************************/
-                        /*                                            */
-                        /* update i_count at each iteration.          */
-                        /*                                            */
-                        /**********************************************/
-
-                        i_count = clrx[i-1] - clrx[i_start-1];
-
-                        for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                        {
-                            status = auto_ts_fit(clrx, clry, i_b, i_start-1, i-1, update_num_c, 
-                                                 fit_cft, &rmse[i_b], rec_v_dif); 
-                            if (status != SUCCESS) 
-			    { 
-                                RETURN_ERROR ("Calling auto_ts_fit during continuous monitoring\n", 
-                                              FUNC_NAME, FAILURE);
-			    }
-                        }
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Updating information for the first         */
-                        /* iteration.  Record time of curve start and */
-                        /* time of curve end.                         */
-                        /*                                            */
-                        /**********************************************/
-
-                        rec_cg[num_fc].t_start = clrx[i_start-1]; 
-                        rec_cg[num_fc].t_end = clrx[i-1]; 
-
-                        /**********************************************/
-                        /*                                            */
-                        /* No break at the moment.                    */
-                        /*                                            */
-                        /**********************************************/
-
-                        rec_cg[num_fc].t_break = 0; 
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Record postion of the pixel.               */
-                        /*                                            */
-                        /**********************************************/
-
-                        rec_cg[num_fc].pos.row = row; 
-                        rec_cg[num_fc].pos.col = col; 
-
-                        for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                        {
-                            for (k = 0; k < MAX_NUM_C; k++)
-		 	    {
-                                /**************************************/
-                                /*                                    */
-                                /* Record fitted coefficients.        */
-                                /*                                    */
-                                /**************************************/
-
-                                rec_cg[num_fc].coefs[i_b][k] = fit_cft[i_b][k]; 
-		 	    }
-                            /******************************************/
-                            /*                                        */
-                            /* Record rmse of the pixel.              */
-                            /*                                        */
-                            /******************************************/
-
-                            rec_cg[num_fc].rmse[i_b] = rmse[i_b]; 
-                        }
-                        /**********************************************/
-                        /*                                            */
-                        /* Record change probability, number of       */
-                        /* observations, fit category.                */
-                        /*                                            */
-                        /**********************************************/
-
-                        rec_cg[num_fc].change_prob = 0.0; 
-                        rec_cg[num_fc].num_obs = i-i_start+1; 
-                        rec_cg[num_fc].category = 0 + update_num_c; 
-
-                        for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                        {
-                            /******************************************/
-                            /*                                        */
-                            /* Record change magnitude.               */
-                            /*                                        */
-                            /******************************************/
-                            rec_cg[num_fc].magnitude[i_b] = 0.0; 
-                        }
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Detect change, value of difference for     */
-                        /* CONSE observations.                        */
-                        /*                                            */
-                        /**********************************************/
-
-                        for (i_conse = 0; i_conse < CONSE; i_conse++)
-                        {
-                            v_dif_norm = 0.0;
-                            for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                            {
-                                /**************************************/
-                                /*                                    */
-                                /* Absolute differences.              */
-                                /*                                    */
-                                /**************************************/
-
-        	 	        auto_ts_predict(clrx, fit_cft, update_num_c, i_b, i+i_conse, i+i_conse, 
-                                                &ts_pred_temp);
-                                v_dif_mag[i_b][i_conse] = (float)clry[i_b][i+i_conse] - ts_pred_temp; 
-
-                                /**************************************/
-                                /*                                    */
-                                /* Normalize to z-score.              */
-                                /*                                    */
-                                /**************************************/
-
-                                for (b = 0; b < NUM_LASSO_BANDS; b++)
-                                {
-                                    if (i_b == lasso_blist[b])
-                                    {
-                                        /******************************/
-                                        /*                            */
-                                        /* Minimum rmse,              */ 
-                                        /* z-scores.                  */
-                                        /*                            */
-                                        /******************************/
-
-                                        mini_rmse = max(adj_rmse[i_b], rmse[i_b]);
-                                        v_diff[b][i_conse] = v_dif_mag[i_b][i_conse] / mini_rmse;
-                                        v_dif_norm += v_diff[b][i_conse] * v_diff[b][i_conse];
-                                    }
-                                }
-                            }
-                            vec_mag[i_conse] = v_dif_norm;
-                        }
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Clears the IDs_old buffers.                */
-                        /*                                            */
-                        /**********************************************/
-
-                        for (k = 0; k < ids_len; k++)
-		        {
-                            ids_old[k] = 0;
-		        }
-
-                        /**********************************************/
-                        /*                                            */
-                        /* IDs that have not been updated.            */
-                        /*                                            */
-                        /**********************************************/
-
-                        for (k = 0; k < ids_len; k++)
-			{
-                            ids_old[k] = ids[k];
-			}
-                        ids_old_len = ids_len;
-
-                    }
-                    else
-                    {
-        		if ((float)(clrx[i-1] - clrx[i_start-1]) >= (1.33*(float)i_count))
-                        {
-                            /******************************************/
-                            /*                                        */
-                            /* Update i_count at each iteration year. */
-                            /*                                        */
-                            /******************************************/
-
-                            i_count = clrx[i-1] - clrx[i_start-1];
-
-                            for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                            {
-                                status = auto_ts_fit(clrx, clry, i_b, i_start-1, i-1, update_num_c, 
-                                                 fit_cft, &rmse[i_b], rec_v_dif); 
-                                if (status != SUCCESS)  
-				{
-                                    RETURN_ERROR ("Calling auto_ts_fit for change detection with "
-                                         "enough observations\n", FUNC_NAME, FAILURE);
-				}
-                            }
-
-                            /******************************************/
-                            /*                                        */
-                            /* Record fitted coefficients.            */
-                            /*                                        */
-                            /******************************************/
-                            for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                            {
-                                for (k = 0; k < MAX_NUM_C; k++)
-				{
-                                    /**********************************/
-                                    /*                                */
-                                    /* Record fitted coefficients.    */
-                                    /*                                */
-                                    /**********************************/
-
-                                    rec_cg[num_fc].coefs[i_b][k] = fit_cft[i_b][k];
-				} 
-                                /**************************************/
-                                /*                                    */
-                                /* Record rmse of the pixel.          */
-                                /*                                    */
-                                /**************************************/
-
-                                rec_cg[num_fc].rmse[i_b] = rmse[i_b]; 
-                            }
-                            /******************************************/
-                            /*                                        */
-                            /* Record number of observations, fit     */
-                            /* category.                              */
-                            /*                                        */
-                            /******************************************/
-
-                            rec_cg[num_fc].num_obs = i-i_start+1; 
-                            rec_cg[num_fc].category = 0 + update_num_c; 
-
-                            /******************************************/
-                            /*                                        */
-                            /* Clears the IDs_Old buffers.            */
-                            /*                                        */
-                            /******************************************/
-
-                            for (k = 0; k < ids_len; k++)
-			    {
-                                ids_old[k] = 0;
-			    }
-
-                            /******************************************/
-                            /*                                        */
-                            /* IDs that have not been updated.        */
-                            /*                                        */
-                            /******************************************/
-
-                            for (k = 0; k < ids_len; k++)
-			    {
-                                ids_old[k] = ids[k];
-			    }
-                            ids_old_len = ids_len;
-
-                        }
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Record time of curve end.                  */
-                        /*                                            */
-                        /**********************************************/
-
-                        rec_cg[num_fc].t_end = clrx[i-1];
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Use fixed number for RMSE computing.       */
-                        /*                                            */
-                        /**********************************************/
-
-                        n_rmse = N_TIMES * rec_cg[num_fc].category;
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Better days counting for RMSE calculating  */
-                        /* relative days distance.                    */
-                        /*                                            */
-                        /**********************************************/
-
-			if (ids_old_len == 0)
-			{
-                            RETURN_ERROR ("No data points for RMSE calculating", 
-                                         FUNC_NAME, FAILURE);
-			}
-
-                        d_yr = malloc(ids_old_len * sizeof(float));
-                        if (d_yr == NULL)
-			{
-                            RETURN_ERROR ("Allocating d_yr memory", 
-                                         FUNC_NAME, FAILURE);
-			}
- 
-                        for(m = 0; m < ids_old_len; m++)
-                        {
-                            d_rt = clrx[ids_old[m]] - clrx[i+CONSE-1]; 
-                            d_yr[m] = fabs(round((float)d_rt / NUM_YEARS) * NUM_YEARS - (float)d_rt);
-                        }
-
-                        for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
-                        {
-                            for (m = 0; m < ids_old_len; m++)
-                                rec_v_dif_copy[b][m] = rec_v_dif[b][m];
-                        }
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Sort the rec_v_dif based on d_yr.          */
-                        /*                                            */
-                        /**********************************************/
-
-                        quick_sort_2d_float(d_yr, rec_v_dif_copy, 0, ids_old_len-1);
-                        for(b = 0; b < NUM_LASSO_BANDS; b++)
-                            tmpcg_rmse[b] = 0.0;
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Temporarily changing RMSE.                 */
-                        /*                                            */
-                        /**********************************************/
-
-                        for (b = 0; b < NUM_LASSO_BANDS; b++)
-                        {
-                            matlab_2d_array_norm(rec_v_dif_copy, lasso_blist[b], n_rmse,
-                                             &tmpcg_rmse[b]);
-                            tmpcg_rmse[b] /= sqrt(n_rmse - rec_cg[num_fc].category);
-                        }
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Free allocated memories.                   */
-                        /*                                            */
-                        /**********************************************/
-                        free(d_yr);
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Move the ith col to i-1th col.             */
-                        /*                                            */
-                        /**********************************************/
-
-                        for (m = 0; m < CONSE-1; m++)
-                        {
-                            vec_mag[m] = vec_mag[m+1];
-                            for (b = 0; b < NUM_LASSO_BANDS; b++)
-                                v_diff[b][m] = v_diff[b][m+1];
-                            for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
-                                v_dif_mag[b][m] = v_dif_mag[b][m+1];
-                        }
-
-                        for (b = 0; b < NUM_LASSO_BANDS; b++)
-                            v_diff[b][CONSE-1] = 0.0;
-                        for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
-                            v_dif_mag[b][CONSE-1] = 0.0;
-                        vec_mag[CONSE-1] = 0.0;
-
-                        for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                        {
-                            /******************************************/
-                            /*                                        */
-                            /* Absolute difference for all bands.     */
-                            /*                                        */
-                            /******************************************/
-
-        		    auto_ts_predict(clrx, fit_cft, update_num_c, i_b, i+CONSE-1, 
-                                 i+CONSE-1, &ts_pred_temp);
-                            v_dif_mag[i_b][CONSE-1] = clry[i_b][i+CONSE-1] - ts_pred_temp;
-
-                            /******************************************/
-                            /*                                        */
-                            /* Normalized to z-scores.                */
-                            /*                                        */
-                            /******************************************/
-                            for (b = 0; b < NUM_LASSO_BANDS; b++)
-                            {
-                                if (i_b == lasso_blist[b])
-                                {
-                                    /**********************************/
-                                    /*                                */
-                                    /* Minimum rmse.                  */
-                                    /*                                */
-                                    /**********************************/
-                                    mini_rmse = max(adj_rmse[i_b], tmpcg_rmse[b]);
-
-                                    /**********************************/
-                                    /*                                */
-                                    /* Z-score.                       */
-                                    /*                                */
-                                    /**********************************/
-
-                                    v_diff[b][CONSE-1] = v_dif_mag[i_b][CONSE-1] / mini_rmse;
-                                    vec_mag[CONSE-1] += v_diff[b][CONSE-1] * v_diff[b][CONSE-1]; 
-                                }         
-                            }
-                        }
-		    }
-
-                    break_mag = 9999.0;
-                    for (m = 0; m < CONSE; m++)
-                    {
-                        if (break_mag > vec_mag[m])
-			{
-                            break_mag = vec_mag[m];
-			}
-                    }
-
-                    if (break_mag > T_CG)
-                    {
-
-                        if (verbose)
-                        {
-                            printf("Change Magnitude = %.2f\n", break_mag - T_CG);
-                        }
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Record break time.                        */
-                        /*                                            */
-                        /**********************************************/
-
-                        rec_cg[num_fc].t_break = clrx[i];
-                        rec_cg[num_fc].change_prob = 1.0;
-
-                        for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-			{
-                            quick_sort_float(v_dif_mag[i_b], 0, CONSE-1);
-                            matlab_2d_float_median(v_dif_mag, i_b, CONSE,
-                                                   &rec_cg[num_fc].magnitude[i_b]);
-			}
-                        /**********************************************/
-                        /*                                            */
-                        /* Identified and move on for the next        */
-                        /* functional curve.                          */
-                        /*                                            */
-                        /**********************************************/
-
-                        num_fc++;
-
-                        if (num_fc >= 10)
-		        {
-                            /******************************************/
-                            /*                                        */
-                            /* Reallocate memory for rec_cg.          */ 
-                            /*                                        */
-                            /******************************************/
-
-		            rec_cg = realloc(rec_cg, (num_fc + 1) * sizeof(Output_t));
-                            if (rec_cg == NULL)
-			    {
-                                RETURN_ERROR("ERROR allocating rec_cg memory", 
-                                                     FUNC_NAME, FAILURE);
-			    }
-		        }
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Start from i+1 for the next functional     */
-                        /* curve.                                     */
-                        /*                                            */
-                        /**********************************************/
-
-                        i_start = i + 1;
-
-                        /**********************************************/
-                        /*                                            */
-                        /* Start training again.                      */
-                        /*                                            */
-                        /**********************************************/
-
-                        bl_train = 0;
-                    }
-                    else if (vec_mag[0] > T_MAX_CG)
-                    {
-                        /**********************************************/
-                        /*                                            */
-                        /* Remove noise.                              */
-                        /*                                            */
-                        /**********************************************/
-
-                        for (m = i; m < end -1; m++)
-                        {
-                            clrx[m] = clrx[m+1];
-                            for (b = 0; b < TOTAL_IMAGE_BANDS; b++)
-                                clry[b][m] = clry[b][m+1];
-                        }
-
-                        i--;   /* stay & check again after noise removal */
-                    }
-                    status = free_2d_array ((void **) v_diff);
-                    if (status != SUCCESS)
-		    {
-                        RETURN_ERROR ("Freeing memory: v_diff\n", 
-                                      FUNC_NAME, FAILURE);
-		    }
-		} /* end of continuous monitoring */ 
-	    }  /* end of checking basic requrirements */ 
-
-            /**********************************************************/
-            /*                                                        */
-            /* Move forward to the i+1th clear observation.           */
-            /*                                                        */
-            /**********************************************************/
-
-            i++;
-
-        } /* end of "while (i <= end - CONSE) */
-
-        /**************************************************************/
-        /*                                                            */
-        /* Two ways for processing the end of the time series.        */ 
-        /*                                                            */
-        /**************************************************************/
-
-        if (bl_train == 1)
-        {
-
-            /**********************************************************/
-            /*                                                        */
-            /* If no break, find at the end of the time series,       */
-            /* define probability of change based on CONSE.           */
-            /*                                                        */
-            /**********************************************************/
-
-            for (i_conse = CONSE - 1; i_conse >= 0; i_conse--)
-            {
-                if (vec_mag[i_conse] <= T_CG)
-                {
-                    /**************************************************/
-                    /*                                                */
-                    /* The last stable ID.                            */
-                    /*                                                */
-                    /**************************************************/
-
-                    id_last = i_conse + 1;
-                    break;
-                }
-            } 
-
-            /**********************************************************/
-            /*                                                        */
-            /* Update change probability, end time of the curve.      */
-            /*                                                        */
-            /**********************************************************/
-
-            rec_cg[num_fc].change_prob = (CONSE - id_last) / CONSE; 
-            rec_cg[num_fc].t_end = clrx[end - CONSE + id_last];
-
-            /**********************************************************/
-            /*                                                        */
-            /* Mean value fit for the rest of the pixels < CONSE & > 1*/
-            /*                                                        */
-            /**********************************************************/
-
-            if (CONSE > id_last)
-            {
-                /******************************************************/
-                /*                                                    */
-                /* Update time of the probable change.                */
-                /*                                                    */
-                /******************************************************/
-
-                rec_cg[num_fc].t_break = clrx[end-CONSE+id_last+1];
-
-                /******************************************************/
-                /*                                                    */
-                /* Update magnitude of change.                        */
-                /*                                                    */
-                /******************************************************/
-
-                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-		{
-                    quick_sort_float(v_dif_mag[i_b], id_last, CONSE-2);
-                    matlab_float_2d_partial_median(v_dif_mag, i_b, id_last, CONSE-1,
-                                         &rec_cg[num_fc].magnitude[i_b]);
-		}
-	    }
-        }
-
-        else if (bl_train == 0)
-
-        {
-            /**********************************************************/
-            /*                                                        */
-            /* If break found close to the end of the time series,    */ 
-            /* use [CONSE,MIN_NUM_C*N_TIMES+CONSE) to fit curve.      */
-            /*                                                        */
-            /* Update i_start.                                        */
-            /*                                                        */
-            /**********************************************************/
-            if (num_fc == rec_fc)
-            {
-                /******************************************************/
-                /*                                                    */
-                /* First curve.                                       */
-                /*                                                    */
-                /******************************************************/
-
-                i_start = 1;
-            }
-            else
-            {
-                for (k = 0; k < valid_num_scenes; k++) 
-                {
-                     if (clrx[k] >= rec_cg[num_fc-1].t_break)
-		     {
-                         i_start = k + 1;
-			 break;
-		     }
-                }
-            }
-
-            for (m = 0; m < valid_num_scenes; m++)
-	    {
-                bl_ids[m] = 0;
-	    }
-
-	    if ((end - i_start + 1) > CONSE)
-	    {
-                /******************************************************/
-                /*                                                    */
-                /* Multitemporal cloud mask.                          */
-                /*                                                    */
-                /******************************************************/
-
-                status = auto_mask(clrx, clry, i_start-1, end-1,
-                               (float)(clrx[end-1]-clrx[i_start-1]) / NUM_YEARS, 
-                               adj_rmse[1], adj_rmse[4], T_CONST, bl_ids);
-                if (status != SUCCESS)
-                    RETURN_ERROR("ERROR calling auto_mask at the end of time series", 
-                                  FUNC_NAME, FAILURE);
-
-                /******************************************************/
-                /*                                                    */
-                /* Clears the IDs buffers.                            */
-                /*                                                    */
-                /******************************************************/
-
-                for (m = 0; m < valid_num_scenes-1; m++)
-        	{
-                    ids[m] = 0;
-	        }
-
-                /******************************************************/
-                /*                                                    */
-                /* IDs to be removed.                                 */
-                /*                                                    */
-                /******************************************************/
-
-                for (k = i_start-1; k < end; k++)
-		{
-                    ids[k-i_start+1] = k;
-      	        }
-                m= 0;
-                i_span = 0;
-                for (k = 0; k < end-i_start+1; k++)
-                {
-                    if (bl_ids[k] == 1) 
-                    {
-                        rm_ids[m] = ids[k];
-                        m++;
-                    }
-                    else
-                        i_span++;  /* update i_span after noise removal */
-                }
-                rm_ids_len = m;
-
-                /******************************************************/
-                /*                                                    */
-                /* Remove noise pixels between i_start & i .          */
-                /*                                                    */
-                /******************************************************/
-
-                m = 0;
-                for (k = 0, k_new=0; k < end-i_start+1; k++)
-                {
-                    if (m < rm_ids_len && k == rm_ids[m])
-                    {
-                        m++;
-			continue;
-                    }
-                    clrx[k_new] = clrx[k];
                     for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                        clry[i_b][k_new] = clry[i_b][k];
-                    k_new++;
+                    {
+                        status = auto_ts_fit(clrx, clry, i_b, i_start-1, end-1, MIN_NUM_C, 
+                                             fit_cft, &rmse[i_b], temp_v_dif); 
+                        if (status != SUCCESS)  
+                        {
+                             RETURN_ERROR ("Calling auto_ts_fit at the end of time series\n", 
+                                    FUNC_NAME, FAILURE);
+                        }
+                    }
+
+                    /******************************************************/
+                    /*                                                    */
+                    /* Record time of curve start, time of curve end,     */
+                    /* break time, postion of the pixel.                  */
+                    /*                                                    */
+                    /******************************************************/
+
+                    rec_cg[num_fc].t_start = clrx[i_start-1];
+                    rec_cg[num_fc].t_end = clrx[end-1];
+                    rec_cg[num_fc].t_break = 0;
+                    rec_cg[num_fc].pos = (row-1) * ncols + col_inx + 1; // offsets
+
+                    /******************************************************/
+                    /*                                                    */
+                    /* Record fitted coefficients.                        */
+                    /*                                                    */
+                    /******************************************************/
+
+                    for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                    {
+                        for (k = 0; k < MAX_NUM_C; k++)
+                        {
+                            rec_cg[num_fc].coefs[i_b][k] = fit_cft[i_b][k];
+                        }
+                        rec_cg[num_fc].rmse[i_b] = rmse[i_b];
+                    }
+
+                    /******************************************************/
+                    /*                                                    */
+                    /* Record change probability, number of observations, */
+                    /* fit category.                                      */
+                    /*                                                    */
+                    /******************************************************/
+
+                    rec_cg[num_fc].change_prob = 0.0;
+                    rec_cg[num_fc].num_obs = i_span;
+                    rec_cg[num_fc].category = 20 + MIN_NUM_C; /* simple model fit at the end */
+
+                    /******************************************************/
+                    /*                                                    */
+                    /* Record change magnitude.                           */
+                    /*                                                    */
+                    /******************************************************/
+
+                    for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
+                    {
+                        rec_cg[num_fc].magnitude[i_b] = 0.0; 
+                    }
                 }
-                end = k_new;
-	    }
-
-	    if ((end - i_start + 1) >= CONSE)
-	    {
-                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                {
-                    status = auto_ts_fit(clrx, clry, i_b, i_start-1, end-1, MIN_NUM_C, 
-                                         fit_cft, &rmse[i_b], temp_v_dif); 
-                    if (status != SUCCESS)  
-		    {
-                         RETURN_ERROR ("Calling auto_ts_fit at the end of time series\n", 
-                                FUNC_NAME, FAILURE);
-		    }
-                }
-
-                /******************************************************/
-                /*                                                    */
-                /* Record time of curve start, time of curve end,     */
-                /* break time, postion of the pixel.                  */
-                /*                                                    */
-                /******************************************************/
-
-	        if (num_fc == rec_fc)
-	        {
-                    rec_cg[num_fc].t_start = clrx[0];
-	        }
-	        else
-	        {
-                    rec_cg[num_fc].t_start = rec_cg[num_fc-1].t_break;
-	        }
-                rec_cg[num_fc].t_end = clrx[end-1];
-                rec_cg[num_fc].t_break = 0;
-                rec_cg[num_fc].pos.row = row;
-                rec_cg[num_fc].pos.col = col;
-
-                /******************************************************/
-                /*                                                    */
-                /* Record fitted coefficients.                        */
-                /*                                                    */
-                /******************************************************/
-
-                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-                {
-                    for (k = 0; k < MAX_NUM_C; k++)
-		    {
-                        rec_cg[num_fc].coefs[i_b][k] = fit_cft[i_b][k];
-		    }
-                    rec_cg[num_fc].rmse[i_b] = rmse[i_b];
-                }
-
-                /******************************************************/
-                /*                                                    */
-                /* Record change probability, number of observations, */
-                /* fit category.                                      */
-                /*                                                    */
-                /******************************************************/
-
-                rec_cg[num_fc].change_prob = 0.0;
-                rec_cg[num_fc].num_obs = i_span;
-                rec_cg[num_fc].category = 20 + MIN_NUM_C; /* simple model fit at the end */
-
-                /******************************************************/
-                /*                                                    */
-                /* Record change magnitude.                           */
-                /*                                                    */
-                /******************************************************/
-
-                for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
-	        {
-                    rec_cg[num_fc].magnitude[i_b] = 0.0; 
-	        }
-                num_fc++;
-                if (num_fc >= 10)
-	        {
-                    /**************************************************/
-                    /*                                                */
-                    /* Reallocate memory for rec_cg.                  */ 
-                    /*                                                */
-                    /**************************************************/
-
-		    rec_cg = realloc(rec_cg, (num_fc + 1) * sizeof(Output_t));
-                    if (rec_cg == NULL)
-		    {
-                        RETURN_ERROR("ERROR allocating rec_cg memory", 
-                                     FUNC_NAME, FAILURE);
-		    }
-		}
-	    }
+            }
         }
-    }
+      } // for ncols
+    } // for nrows
 
     free(updated_fmask_buf);
-    status = free_2d_array ((void **) buf);
-    if (status != SUCCESS)
-    {
-        RETURN_ERROR ("Freeing memory: buf\n", 
-                      FUNC_NAME, FAILURE);
-    }
+    //status = free_2d_array ((void **) buf);
+    //if (status != SUCCESS)
+    //{
+    //    RETURN_ERROR ("Freeing memory: buf\n", 
+    //                  FUNC_NAME, FAILURE);
+    //}
+    free(buf);
 
     /******************************************************************/
     /*                                                                */
@@ -2928,10 +3017,11 @@ int main (int argc, char *argv[])
     /******************************************************************/
 
     free(updated_sdate_array);
-    free(clrx);
+    //free(clrx);
     free(rmse);
     free(vec_mag);
-    free(id_range);
+    //free(vec_magg);
+    //free(id_range);
     status = free_2d_array ((void **) rec_v_dif);
     if (status != SUCCESS)
     {
@@ -2983,10 +3073,10 @@ int main (int argc, char *argv[])
         }
     }
 
-    free(ids);
-    free(ids_old);
-    free(rm_ids);
-    free(bl_ids);
+    //free(ids);
+    //free(ids_old);
+    //free(rm_ids);
+    //free(bl_ids);
     status = free_2d_array ((void **) temp_v_dif);
     if (status != SUCCESS)
     {
@@ -3064,8 +3154,7 @@ int main (int argc, char *argv[])
             printf("rec_cg[0].t_start=%d\n",rec_cg[0].t_start);
             printf("rec_cg[0].t_end=%d\n",rec_cg[0].t_end);
             printf("rec_cg[0].t_break=%d\n",rec_cg[0].t_break);
-            printf("rec_cg[0].pos.row=%d\n",rec_cg[0].pos.row);
-            printf("rec_cg[0].pos.col=%d\n",rec_cg[0].pos.col);
+            printf("rec_cg[0].pos=%d\n",rec_cg[0].pos);
             printf("rec_cg[0].num_obs=%d\n",rec_cg[0].num_obs);
             printf("rec_cg[0].category=%d\n",rec_cg[0].category);
             for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
@@ -3093,8 +3182,7 @@ int main (int argc, char *argv[])
                 printf("rec_cg[%d].t_start=%d\n",i,rec_cg[i].t_start);
                 printf("rec_cg[%d].t_end=%d\n",i,rec_cg[i].t_end);
                 printf("rec_cg[%d].t_break=%d\n",i,rec_cg[i].t_break);
-                printf("rec_cg[%d].pos.row=%d\n",i,rec_cg[i].pos.row);
-                printf("rec_cg[%d].pos.col=%d\n",i,rec_cg[i].pos.col);
+                printf("rec_cg[%d].pos=%d\n",i,rec_cg[i].pos);
                 printf("rec_cg[%d].num_obs=%d\n",i,rec_cg[i].num_obs);
                 printf("rec_cg[%d].category=%d\n",i,rec_cg[i].category);
                 for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
@@ -3125,8 +3213,7 @@ int main (int argc, char *argv[])
             printf("%d\n",rec_cg[0].t_start);
             printf("%d\n",rec_cg[0].t_end);
             printf("%d\n",rec_cg[0].t_break);
-            printf("%d\n",rec_cg[0].pos.row);
-            printf("%d\n",rec_cg[0].pos.col);
+            printf("%d\n",rec_cg[0].pos);
             printf("%d\n",rec_cg[0].num_obs);
             printf("%d\n",rec_cg[0].category);
             for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
@@ -3154,8 +3241,7 @@ int main (int argc, char *argv[])
                 printf("%d\n",rec_cg[i].t_start);
                 printf("%d\n",rec_cg[i].t_end);
                 printf("%d\n",rec_cg[i].t_break);
-                printf("%d\n",rec_cg[i].pos.row);
-                printf("%d\n",rec_cg[i].pos.col);
+                printf("%d\n",rec_cg[i].pos);
                 printf("%d\n",rec_cg[i].num_obs);
                 printf("%d\n",rec_cg[i].category);
                 for (i_b = 0; i_b < TOTAL_IMAGE_BANDS; i_b++)
@@ -3224,15 +3310,17 @@ usage ()
 {
     printf ("\n");
     printf ("Continuous Change Detection and Classification\n");
-    printf ("Version 05.01\n");
+    printf ("Version 05.02\n");
     printf ("\n");
     printf ("usage:\n");
     printf ("ccdc"
             " --row=<input row number>"
             " --col=<input col number>"
-            " [--in-path=<input directory>"
-            " [--out-path=<output directory[>"
-            " [--data-type=<tifs|bip[>"
+            " --num-rows=<number of rows>"
+            " --num-cols=<number of columns>"
+            " [--in-path=<input directory>]"
+            " [--out-path=<output directory>]"
+            " [--data-type=<tifs|bip]"
             " [--scene-list-file=<file with list of sceneIDs>]"
             " [--verbose]\n");
 
@@ -3242,6 +3330,8 @@ usage ()
     printf ("    --col=: input col number\n");
     printf ("\n");
     printf ("and the following parameters are optional:\n");
+    printf ("    --num-rows=: input number of rows\n");
+    printf ("    --num-cols=: input number of columns\n");
     printf ("    --in-path=: input data directory location\n");
     printf ("    --out-path=: directory location for output files\n");
     printf ("    --data-type=: type of input data files to ingest\n");
@@ -3256,6 +3346,8 @@ usage ()
     printf ("ccdc"
             " --row=3845"
             " --col=2918"
+            " --num-rows=1"
+            " --num-cols=1"
             " --in-path=/data/user/in"
             " --out-path=/home/user/out"
             " --data-type=bip"

--- a/ccdc/ccdc.h
+++ b/ccdc/ccdc.h
@@ -17,6 +17,8 @@ int get_args
     char *argv[],          /* I: string of cmd-line args                    */
     int *row,              /* O: row number for the pixel                   */
     int *col,              /* O: col number for the pixel                   */
+    int *nrows,            /* O: number of Y pixels for the tile            */
+    int *ncols,            /* O: number of X pixels for the tile            */
     char *in_path,         /* O: directory location of input data           */
     char *out_path,        /* O: direcotry location of output files         */
     char *data_type,       /* O: data type: tifs, bip, stdin, bip_lines.    */
@@ -112,7 +114,7 @@ void matlab_2d_array_mean
     float **array,       /* I: input array                         */
     int dim1_index,      /* I: 1st dimension index                 */   
     int dim2_len,        /* I: number of input elements in 2nd dim */
-    float  *output_mean  /* O: output norm value                   */
+    float *output_mean   /* O: output norm value                   */
 );
 
 void matlab_2d_float_median
@@ -129,7 +131,7 @@ void matlab_2d_partial_mean
     int dim1_index,      /* I: 1st dimension index                 */
     int start,           /* I: number of start elements in 2nd dim */
     int end,             /* I: number of end elements in 2nd dim   */
-    float  *output_mean  /* O: output norm value                   */
+    float *output_mean   /* O: output norm value                   */
 );
 
 void matlab_float_2d_partial_median
@@ -378,15 +380,15 @@ extern int solns_(
 );
 
 extern int c_glmnet(
-    int no,		   // number of observations (no)
-    int ni,		   // number of predictor variables (ni)
-    double *x,		   // input matrix, x[ni][no]
-    double *y,		   // response vaiable, of dimentions (no)
-    int nlam,		   // number of lambda values
-    double *ulam,	   // value of lambda values, of dimentions (nlam)
-    double parm,	   // the alpha variable
+    int no,             // number of observations (no)
+    int ni,             // number of predictor variables (ni)
+    double *x,          // input matrix, x[ni][no]
+    double *y,          // response vaiable, of dimentions (no)
+    int nlam,           // number of lambda values
+    double *ulam,       // value of lambda values, of dimentions (nlam)
+    double parm,        // the alpha variable
 
-    int *lmu,		   // lmu = actual number of lamda values (solutions)
+    int *lmu,           // lmu = actual number of lamda values (solutions)
     double cfs[nlam][ni+1] // results = cfs[lmu][ni + 1]
 );
 

--- a/ccdc/const.h
+++ b/ccdc/const.h
@@ -53,6 +53,6 @@ typedef signed char int8;
 #define MINSIGMA 1e-5
 
 #define MAX_STR_LEN 512
-#define MAX_SCENE_LIST 3922
+#define MAX_SCENE_LIST 5000
 
 #endif

--- a/ccdc/defines.h
+++ b/ccdc/defines.h
@@ -6,7 +6,7 @@
 /* from ccdc.c */
 #define NUM_LASSO_BANDS 5 /* Number of bands for Least Absolute Shrinkage */
                           /* and Selection Operator LASSO regressions */
-#define TOTAL_IMAGE_BANDS 7 /* Number of image bands, for loops.      */
+#define TOTAL_IMAGE_BANDS 7 /* Number of image bands, including thermal*/
 #define TOTAL_BANDS 8     /* Total image plus mask bands, for loops.  */
 #define MIN_NUM_C 4       /* Minimum number of coefficients           */
 #define MID_NUM_C 6       /* Mid-point number of coefficients         */
@@ -14,7 +14,8 @@
 #define CONSE 6           /* No. of CONSEquential pixels 4 bldg. model*/
 #define N_TIMES 3         /* number of clear observations/coefficients*/
 #define NUM_YEARS 365.25  /* average number of days per year          */
-#define NUM_FC 10         /* Values change with number of pixels run  */
+#define MAX_NUM_FC 30000  /* Values change with number of pixels run */
+//#define NUM_FC 10         /* Values change with number of pixels run  */
 #define T_CONST 4.89      /* Threshold for cloud, shadow, and snow detection */
 #define MIN_YEARS 1       /* minimum year for model intialization     */
 #define T_SN 0.75         /* no change detection for permanent snow pixels */ 
@@ -60,6 +61,7 @@
 #define CFMASK_FILL  255
 #define IMAGE_FILL -9999
 #define CFMASK_BAND    7
+#define THERMAL_BAND   6
 
 /* from output.h */
 #define FILL_VALUE 255

--- a/ccdc/input.h
+++ b/ccdc/input.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include "const.h"
 
-/* possible cfmask values */
+/* All defines in one file to avoid conflicts */
 #include "defines.h"
 
 /* Input file type definition */
@@ -20,64 +20,64 @@ typedef enum {
 
 /* Structure for the metadata */
 typedef struct {
-    int lines;            /* number of lines in a scene */ 
-    int samples;          /* number of samples in a scene */
-    int data_type;        /* envi data type */
-    int byte_order;       /* envi byte order */
-    int utm_zone;         /* UTM zone; use a negative number if this is a
-                             southern zone */
-    int pixel_size;       /* pixel size */
-    char interleave[MAX_STR_LEN];  /* envi save format */ 
-    int  upper_left_x;    /* upper left x coordinates */                         
-    int  upper_left_y;    /* upper left y coordinates */ 
+    int lines;          /* number of lines in a scene                         */ 
+    int samples;        /* number of samples in a scene                       */
+    int data_type;      /* envi data type                                     */
+    int byte_order;     /* envi byte order                                    */
+    int utm_zone;       /* UTM zone; use a negative number if this is a
+                             southern zone                                    */
+    int pixel_size;     /* pixel size                                         */
+    char interleave[MAX_STR_LEN];  /* envi save format                        */ 
+    int  upper_left_x;  /* upper left x coordinates                           */                         
+    int  upper_left_y;  /* upper left y coordinates                           */ 
 } Input_meta_t;
 
 /* Structure for the 'input' data type */
 typedef struct {
   Input_type_t file_type;  /* Type of the input image files */
   Input_meta_t meta;       /* Input metadata */
-  FILE *fp_bin[TOTAL_BANDS][MAX_SCENE_LIST];           
+  FILE *fp_bin[TOTAL_BANDS][MAX_SCENE_LIST]; /* file pointer for image files  */
 } Input_t;
 
 /* Prototypes */
 FILE *open_raw_binary
 (
-    char *infile,        /* I: name of the input file to be opened */
-    char *access_type    /* I: string for the access type for reading the
-                               input file */
+    char *infile,       /* I: name of the input file to be opened             */
+    char *access_type   /* I: string for the access type for reading the
+                               input file                                     */
 );
 
 void close_raw_binary
 (
-    FILE *fptr      /* I: pointer to raw binary file to be closed */
+    FILE *fptr          /* I: pointer to raw binary file to be closed         */
 );
 
 int write_raw_binary
 (
-    FILE *rb_fptr,      /* I: pointer to the raw binary file */
-    int nlines,         /* I: number of lines to write to the file */
-    int nsamps,         /* I: number of samples to write to the file */
-    int size,           /* I: number of bytes per pixel (ex. sizeof(uint8)) */
+    FILE *rb_fptr,      /* I: pointer to the raw binary file                  */
+    int nlines,         /* I: number of lines to write to the file            */
+    int nsamps,         /* I: number of samples to write to the file          */
+    int size,           /* I: number of bytes per pixel (ex. sizeof(uint8))   */
     void *img_array     /* I: array of nlines * nsamps * size to be written
-                              to the raw binary file */
+                              to the raw binary file                          */
 );
 
 int read_raw_binary
 (
-    FILE *rb_fptr,      /* I: pointer to the raw binary file */
-    int nlines,         /* I: number of lines to read from the file */
-    int nsamps,         /* I: number of samples to read from the file */
-    int size,           /* I: number of bytes per pixel (ex. sizeof(uint8)) */
+    FILE *rb_fptr,      /* I: pointer to the raw binary file                  */
+    int nlines,         /* I: number of lines to read from the file           */
+    int nsamps,         /* I: number of samples to read from the file         */
+    int size,           /* I: number of bytes per pixel (ex. sizeof(uint8))   */
     void *img_array     /* O: array of nlines * nsamps * size to be read from
                               the raw binary file (sufficient space should
-                              already have been allocated) */
+                              already have been allocated)                    */
 );
 
 int read_envi_header
 (
-    char *data_type,       /* I: input data type        */
-    char *scene_name,      /* I: scene name             */
-    Input_meta_t *meta     /* O: saved header file info */
+    char *data_type,    /* I: input data type                                 */
+    char *scene_name,   /* I: scene name                                      */
+    Input_meta_t *meta  /* O: saved header file info                          */
 );
 
 int read_cfmask
@@ -87,6 +87,8 @@ int read_cfmask
     char **scene_list,   /* I:   current scene name in list of sceneIDs       */
     int  row,            /* I:   the row (Y) location within img/grid         */
     int  col,            /* I:   the col (X) location within img/grid         */
+    int  nrows,          /* I:   number of rows to read in a tile of some data*/
+    int  ncols,          /* I:   number of cols to read in a line of bip data */
     int  num_samples,    /* I:   number of image samples (X width)            */
     FILE ***fp_tifs,     /* I/O: file ptr array for tif band file names       */
     FILE **fp_bip,       /* I/O: file pointer array for BIP file names        */
@@ -108,7 +110,7 @@ int read_cfmask
     int *sn_sum,         /* I/O: Total number of snow cfmask pixels           */
     int *cloud_sum,      /* I/O: counter for cfmask cloud pixels.             */
     int *fill_sum,       /* I/O: counter for cfmask fill pixels.              */
-    int *all_sum,         /* I/O: Total of all cfmask pixels                   */
+    int *all_sum,        /* I/O: Total of all cfmask pixels                   */
     unsigned char *updated_fmask_buf, /* I/O: new entry in valid fmask values */
     int *updated_sdate_array, /* I/O: new buf of valid date values            */
     int *sdate,          /* I:   Original array of julian date values         */
@@ -118,57 +120,61 @@ int read_cfmask
 
 int read_stdin
 (
-    int           *updated_sdate_array, /* pointer to date values buffer. */
-    int           **buf,                /* pointer to image bands buffer. */
-    unsigned char *updated_cfmask_buf,  /* pointer to cfmask pixel buffer.*/
-    int           num_bands,            /* total number of bands.         */
-    int           *clear_sum,           /* accumulator for clear  pixels. */
-    int           *water_sum,           /* accumulator for water  pixels. */
-    int           *shadow_sum,          /* accumulator for shadow pixels. */
-    int           *snow_sum,            /* accumulator for snow   pixels. */
-    int           *cloud_sum,           /* accumulator for cloud  pixels. */
-    int           *fill_sum,            /* accumulator for fill   pixels. */
-    int           *all_sum,             /* accumulator for all    pixels. */
-    int           *valid_num_scenes,    /* total scenes read.             */
-    bool          debug                 /* flag for printing mesgs/info.  */
+    int           *updated_sdate_array, /* O:   pointer to date values buffer */
+    int           *buf,                 /* O:   pointer to image bands buffer */
+    unsigned char *updated_cfmask_buf,  /* O:   pointer to cfmask pixel buffer*/
+    int           num_bands,            /* I:   total number of bands         */
+    int           *clear_sum,           /* O:   accumulator for clear  pixels */
+    int           *water_sum,           /* O:   accumulator for water  pixels */
+    int           *shadow_sum,          /* O:   accumulator for shadow pixels */
+    int           *snow_sum,            /* O:   accumulator for snow   pixels */
+    int           *cloud_sum,           /* O:   accumulator for cloud  pixels */
+    int           *fill_sum,            /* O:   accumulator for fill   pixels */
+    int           *all_sum,             /* O:   accumulator for all    pixels */
+    int           *valid_num_scenes,    /* O:   total scenes read             */
+    bool          debug                 /* I:   flag for printing mesgs/info  */
 );
 
 
 int assign_cfmask_values
 (
-    unsigned char cfmask_value,         /* I: current cfmask pixel value.   */
-    int           *clear_sum,           /* O: accumulator for clear  pixels */
-    int           *water_sum,           /* O: accumulator for water  pixels */
-    int           *shadow_sum,          /* O: accumulator for shadow pixels */
-    int           *snow_sum,            /* O: accumulator for snow   pixels */
-    int           *cloud_sum,           /* O: accumulator for cloud  pixels */
-    int           *fill_sum,            /* O: accumulator for full   pixels */
-    int           *all_sum              /* O: accumulator for all    pixels */
+    unsigned char cfmask_value,         /* I: current cfmask pixel value.     */
+    int           *clear_sum,           /* O: accumulator for clear  pixels   */
+    int           *water_sum,           /* O: accumulator for water  pixels   */
+    int           *shadow_sum,          /* O: accumulator for shadow pixels   */
+    int           *snow_sum,            /* O: accumulator for snow   pixels   */
+    int           *cloud_sum,           /* O: accumulator for cloud  pixels   */
+    int           *fill_sum,            /* O: accumulator for full   pixels   */
+    int           *all_sum              /* O: accumulator for all    pixels   */
 );
 
 
 int read_tifs
 (
-    char *sceneID_name,  /* I:   current file name in list of sceneIDs  */
-    FILE ***fp_tifs,     /* I/O: file pointer array for band file names */
-    int  curr_scene_num, /* I:   current num. in list of scenes to read */
-    int  row,            /* I:   the row (Y) location within img/grid   */
-    int  col,            /* I:   the col (X) location within img/grid   */
-    int  num_samples,    /* I:   number of image samples (X width)      */
-    bool debug,          /* I:   flag for printing debug messages       */
-    int  **image_buf     /* O:   pointer to 2-D image band values array */
+    char *sceneID_name,  /* I:   current file name in list of sceneIDs        */
+    FILE ***fp_tifs,     /* I/O: file pointer array for band file names       */
+    int  curr_scene_num, /* I:   current num. in list of scenes to read       */
+    int  row,            /* I:   the row (Y) location within img/grid         */
+    int  col,            /* I:   the col (X) location within img/grid         */
+    int  nrows,          /* I:   number of rows to read in tile of data */
+    int  ncols,          /* I:   number of colums to read (1 for bip)   */
+    int  num_samples,    /* I:   number of image samples (X width)            */
+    bool debug,          /* I:   flag for printing debug messages             */
+    int  *image_buf      /* O:   pointer to 2-D image band values array       */
 );
 
 
 int read_bip
 (
     char *current_scene_name, /* I:   current file name in list of sceneIDs  */
-    FILE **fp_bip,           /* I/O: file pointer array for BIP  file names */
+    FILE **fp_bip,            /* I/O: file pointer array for BIP  file names */
     int  curr_scene_num,      /* I:   current num. in list of scenes to read */
     int  row,                 /* I:   the row (Y) location within img/grid   */
     int  col,                 /* I:   the col (X) location within img/grid   */
+    int  nrows,               /* I:   number of rows to read in tile of data */
+    int  ncols,               /* I:   number of colums to read (1 for bip)   */
     int  num_samples,         /* I:   number of image samples (X width)      */
-    int  **image_buf          /* O:   pointer to 2-D image band values array */
+    int  *image_buf           /* O:   pointer to 2-D image band values array */
 );
 
 

--- a/ccdc/make.sh
+++ b/ccdc/make.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This parent bash script to make allows for dynamic env configuration.
+# Ror example, gsl is now a dependency.
+
+# for example: clean; install; -n
+
+make_arg=$1
+
+BIN=/alt/local/run/contrib/ccdc
+GSL_HOME=/alt/local/gsl/1.16.ccdc
+
+GSL_SCI_INC=$GSL_HOME/include GSL_SCI_LIB=$GSL_HOME/lib make $make_arg >& make.out
+
+more make.out
+
+exit
+
+

--- a/ccdc/output.h
+++ b/ccdc/output.h
@@ -1,6 +1,7 @@
 #ifndef OUTPUT_H
 #define OUTPUT_H
 
+/* Aall defines in one file to avoid conflicts */
 #include "defines.h"
 
 typedef struct {
@@ -20,7 +21,8 @@ typedef struct
     float rmse[NUM_BANDS];
                            /*  RMSE for each time series model for each 
                                spectral band*/    
-    Position_t pos;        /* the location of each time series model */
+    //Position_t pos;        /* the location of each time series model */
+    int pos;               /* the pixel location of each time series model */
     float change_prob;     /* the probability of a pixel that have undergone 
                               change (between 0 and 100) */
     int num_obs;           /* the number of "good" observations used for model 

--- a/ccdc/utilities.c
+++ b/ccdc/utilities.c
@@ -7,9 +7,7 @@
 #include <unistd.h>
 #include <libgen.h>
 
-
 #include "utilities.h"
-
 
 /*****************************************************************************
   NAME:  write_message

--- a/ccdc/utilities.h
+++ b/ccdc/utilities.h
@@ -29,13 +29,13 @@
 
 void write_message
 (
-    const char *message, /* I: message to write to the log */
-    const char *module,  /* I: module the message is from */
-    const char *type,    /* I: type of the error */
-    char *file,          /* I: file the message was generated in */
-    int line,            /* I: line number in the file where the message was
-                               generated */
-    FILE * fd            /* I: where to write the log message */
+    const char *message, /* I: message to write to the log            */
+    const char *module,  /* I: module the message is from             */
+    const char *type,    /* I: type of the error                      */
+    char *file,          /* I: file the message was generated in      */
+    int line,            /* I: line number in the file where the
+                               message was generated */
+    FILE * fd            /* I: where to write the log message         */
 );
 
 


### PR DESCRIPTION
- Fixed problems with median_variogram in misc.c
- Fixed problems with matlab_unique in misc.c
- ccdc.c: Changed initialization of num_fc from 0 to 1 (sguo)
- added nrows and ncols to reading to enable tiles of input
- fixed ordering of events in section:
  "Snow observations are "good" now."
- fixed inverted loops in section:
  "Treat saturated and unsaturated pixels differently."
- Moved check up for num_fc >= MAX_NUM_FC in section:
  "NUM of Fitted Curves (num_fc)"
- Changed error to continue for check of:
  if (n_clr < N_TIMES \* MIN_NUM_C)
  in section:
  "The first observation for TSFit."
- moved check for
  if (num_fc >= MAX_NUM_FC)
  after section
  "NUM of Fitted Curves (num_fc)"
  instead of at end of loop.
- Additional check for
  if (num_fc >= MAX_NUM_FC)
  in section:
  "Start with mininum requirement of clear obs"
- Removed fatal error of:
  ini_conse == 0
  in section:
  "Model fit at the beginning of the time series"
- Changed:
  if (num_fc >= 10)
  to:
  if (num_fc >= MAX_NUM_FC)
  in section:
  "Identified and move on for the next functional curve"
- Added proper indentation in numerous places.
- Changed:
  if (num_fc >= 10)
  to:
  if (num_fc >= MAX_NUM_FC)
  in 2nd section:
  Identified and move on for the next functional curve"
- Added:
  end--; /\* check if this is needed */
  to remove noise section
- Added:
  end--;
  to section:
  "Remove noise pixels between i_start & i."
  removed:
  end = k_new;
- BIP lines and columns reading and processing and corresponding algorithm
  updates, code updates, bug fixes
- Covert ccdc algorithm in main.c to callable function.
  Moved mallocs down to be inside callable function.
  Moved debug and verbose printfs of status down to be inside callable function
